### PR TITLE
feat: Account API - 조회 api 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
@@ -1,0 +1,39 @@
+package com.example.dgu_semi_erp_back.api.account;
+
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateResponse;
+import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
+import com.example.dgu_semi_erp_back.usecase.account.AccountCreateUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/account")
+@Validated
+public class AccountApi {
+    private final AccountCreateUseCase accountCreateUseCase;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AccountCreateResponse create(
+            @RequestBody @Valid AccountCreateRequest request
+    ){
+        try {
+            var account = accountCreateUseCase.create(request);
+
+            return AccountCreateResponse.builder()
+                    .account(account)
+                    .build();
+        } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (UserNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
@@ -1,0 +1,36 @@
+package com.example.dgu_semi_erp_back.dto.account;
+
+import com.example.dgu_semi_erp_back.entity.account.Account;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public final class AccountCommandDto {
+    private AccountCommandDto() {}
+
+    @Builder
+    public record AccountCreateRequest(
+            String number,
+            LocalDateTime createdAt,
+            Long userId,
+            Long clubId
+    ){}
+
+    @Builder
+    public record AccountCreateResponse(
+            Account account
+    ) {}
+
+    @Builder
+    public record AccountUpdateRequest(
+            String number,
+            LocalDateTime updatedAt,
+            long userId,
+            long clubId
+    ) {}
+
+    @Builder
+    public record AccountUpdateResponse(
+            Account account
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/account/Account.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/account/Account.java
@@ -7,7 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,10 +31,11 @@ public class Account {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
-    private LocalDateTime deletedAt;
+    private Instant deletedAt;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/example/dgu_semi_erp_back/exception/ClubNotFoundException.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/exception/ClubNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.exception;
+
+public class ClubNotFoundException extends RuntimeException {
+    public ClubNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/AccountDtoMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/AccountDtoMapper.java
@@ -1,0 +1,30 @@
+package com.example.dgu_semi_erp_back.mapper;
+
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
+import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.time.Instant;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING)
+public interface AccountDtoMapper {
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "createdAt", source = "dto.createdAt"),
+            @Mapping(target = "user", source = "user"),
+            @Mapping(target = "club", source = "club"),
+            @Mapping(target = "updatedAt", source = "updatedAt"),
+    })
+    Account toEnity(
+            AccountCreateRequest dto,
+            User user,
+            Club club,
+            Instant updatedAt
+    );
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountCommandRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountCommandRepository.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.repository.account;
+
+import com.example.dgu_semi_erp_back.entity.account.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountCommandRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQueryRepository.java
@@ -1,0 +1,8 @@
+package com.example.dgu_semi_erp_back.repository.account;
+
+import com.example.dgu_semi_erp_back.entity.account.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountQueryRepository extends JpaRepository<Account, Long> {
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQuerySupport.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQuerySupport.java
@@ -1,0 +1,4 @@
+package com.example.dgu_semi_erp_back.repository.account;
+
+public class AccountQuerySupport {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.repository.club;
+
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubRepository extends JpaRepository<Club, Long> {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -1,0 +1,43 @@
+package com.example.dgu_semi_erp_back.service.account;
+
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
+import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
+import com.example.dgu_semi_erp_back.mapper.AccountDtoMapper;
+import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
+import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
+import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
+import com.example.dgu_semi_erp_back.usecase.account.AccountCreateUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountCommandService implements AccountCreateUseCase {
+    private final AccountQueryRepository accountQueryRepository;
+    private final UserRepository userRepository;
+    private final ClubRepository clubRepository;
+    private final AccountDtoMapper mapper;
+
+    @Override
+    public Account create(AccountCreateRequest request) {
+        Instant now = Instant.now();
+
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
+
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new UserNotFoundException("해당 사용자가 존재하지 않습니다."));
+
+        Account account = mapper.toEnity(request, user, club, now);
+
+        return accountQueryRepository.save(account);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
@@ -1,0 +1,8 @@
+package com.example.dgu_semi_erp_back.usecase.account;
+
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
+import com.example.dgu_semi_erp_back.entity.account.Account;
+
+public interface AccountCreateUseCase {
+    Account create(AccountCreateRequest request);
+}


### PR DESCRIPTION
## 🔎 관련 이슈
#9 

## 🔎 작업 내용
Account API - 조회 api 구현

### API 명세

| Method | Endpoint        | 설명         | 요청 데이터              | 응답 데이터            |
|--------|-----------------|--------------|-----------------------------------|-------------------------------|
| POST   | /account  | 통장 생성    | AccountCreateRequest(계좌번호, 생성일, 통장소유자 id, 통장 소유 동아리 id) | 생성된 통장 정보 (id 포함)     |

-> 자세한 API 문서: https://documenter.getpostman.com/view/33657317/2sB2cUAiAt

<br/>

- 도메인 추가
   - Bankbook 엔티티 클래스 개선: LocalDateTime -> Instant
   - BankbookRepository 인터페이스 추가 (Spring Data JPA)

- 서비스 로직 구현
   - BankbookService 클래스에서 통장 생성 로직 구현

- API 구현
   - BankbookController에서 /api/bankbooks POST 요청 처리
   - 클라이언트로부터 전달받은 통장 정보를 DB에 저장하고, 저장된 엔티티 반환

- DTO 추가
   - BankbookRequestDto: 클라이언트로부터 받은 통장 생성 요청 데이터
   - BankbookResponseDto: 생성된 통장 데이터 반환


## 🔎 참고사항
Postman API 문서 업데이트
https://documenter.getpostman.com/view/33657317/2sB2cUAiAt