### PR TITLE
feat: 인원관리 동아리 및 인원 목록조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,21 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+tasks.register("compileQuerydsl", JavaCompile) {
+    group = "build"
+    description = "Compiles the Querydsl Q-types"
+    classpath = sourceSets.main.compileClasspath
+    destinationDirectory.set(file(querydslDir))
+    source = sourceSets.main.java
+    options.annotationProcessorPath = configurations.annotationProcessor
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/QuerydslConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.example.dgu_semi_erp_back.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/controller/UserClubMemberController.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/controller/UserClubMemberController.java
@@ -1,0 +1,26 @@
+package com.example.dgu_semi_erp_back.controller;
+
+import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.service.peoplemanagement.UserClubMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserClubMemberController {
+
+    private final UserClubMemberService service;
+
+    @GetMapping("/club-members")
+    public Page<ClubMemberDetail> getClubMembers(
+            @RequestParam(required = false) String clubName,
+            @RequestParam(required = false) MemberStatus status,
+            Pageable pageable
+    ) {
+        return service.getClubMembers(clubName, status, pageable);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/controller/UserClubMemberController.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/controller/UserClubMemberController.java
@@ -1,7 +1,7 @@
 package com.example.dgu_semi_erp_back.controller;
 
 import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import com.example.dgu_semi_erp_back.service.peoplemanagement.UserClubMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,7 +18,7 @@ public class UserClubMemberController {
     @GetMapping("/club-members")
     public Page<ClubMemberDetail> getClubMembers(
             @RequestParam(required = false) String clubName,
-            @RequestParam(required = false) MemberStatus status,
+            @RequestParam(required = false) ClubStatus status,
             Pageable pageable
     ) {
         return service.getClubMembers(clubName, status, pageable);

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/peoplemanagement/UserClubMemberDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/peoplemanagement/UserClubMemberDto.java
@@ -1,0 +1,21 @@
+package com.example.dgu_semi_erp_back.dto.peoplemanagement;
+
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.Role;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public final class UserClubMemberDto {
+    private UserClubMemberDto() {}
+
+    @Builder
+    public record ClubMemberDetail(
+            String name,
+            String major,
+            Integer studentNumber,
+            Role role,
+            LocalDateTime joinedAt,
+            MemberStatus status
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/auth/user/User.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/auth/user/User.java
@@ -36,6 +36,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(nullable = false)
+    private String major;
+
+    @Column(nullable = false)
+    private Integer studentNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/club/Club.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/club/Club.java
@@ -28,7 +28,7 @@ public class Club {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private MemberStatus status;
+    private ClubStatus status;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/UserClubMemberMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/UserClubMemberMapper.java
@@ -1,0 +1,16 @@
+package com.example.dgu_semi_erp_back.mapper;
+
+import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface UserClubMemberMapper {
+
+    @Mapping(source = "user.nickname", target = "name")
+    @Mapping(source = "user.major", target = "major")
+    @Mapping(source = "user.studentNumber", target = "studentNumber")
+    @Mapping(source = "registeredAt", target = "joinedAt")
+    ClubMemberDetail toDto(ClubMember clubMember);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
@@ -2,10 +2,10 @@ package com.example.dgu_semi_erp_back.repository.peoplemanagement;
 
 
 import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface UserQueryRepository {
-    Page<ClubMemberDetail> findClubMembers(String clubName, MemberStatus status, Pageable pageable);
+    Page<ClubMemberDetail> findClubMembers(String clubName, ClubStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
@@ -1,0 +1,11 @@
+package com.example.dgu_semi_erp_back.repository.peoplemanagement;
+
+
+import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+    Page<ClubMemberDetail> findClubMembers(String clubName, MemberStatus status, Pageable pageable);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.example.dgu_semi_erp_back.repository.peoplemanagement;
+
+import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.QClub;
+import com.example.dgu_semi_erp_back.entity.club.QClubMember;
+import com.example.dgu_semi_erp_back.entity.auth.user.QUser;
+import com.example.dgu_semi_erp_back.mapper.UserClubMemberMapper;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final UserClubMemberMapper mapper;
+
+    @Override
+    public Page<ClubMemberDetail> findClubMembers(String clubName, MemberStatus status, Pageable pageable) {
+        QClub club = QClub.club;
+        QClubMember cm = QClubMember.clubMember;
+        QUser user = QUser.user;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        if (clubName != null) builder.and(club.name.eq(clubName));
+        if (status != null) builder.and(cm.status.eq(status));
+
+        List<ClubMemberDetail> content = queryFactory
+                .selectFrom(cm)
+                .join(cm.club, club).fetchJoin()
+                .join(cm.user, user).fetchJoin()
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+
+        Long count = queryFactory
+                .select(cm.count())
+                .from(cm)
+                .join(cm.club, club)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.example.dgu_semi_erp_back.repository.peoplemanagement;
 
 import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import com.example.dgu_semi_erp_back.entity.club.QClub;
 import com.example.dgu_semi_erp_back.entity.club.QClubMember;
 import com.example.dgu_semi_erp_back.entity.auth.user.QUser;
@@ -22,14 +22,14 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
     private final UserClubMemberMapper mapper;
 
     @Override
-    public Page<ClubMemberDetail> findClubMembers(String clubName, MemberStatus status, Pageable pageable) {
+    public Page<ClubMemberDetail> findClubMembers(String clubName, ClubStatus status, Pageable pageable) {
         QClub club = QClub.club;
         QClubMember cm = QClubMember.clubMember;
         QUser user = QUser.user;
 
         BooleanBuilder builder = new BooleanBuilder();
         if (clubName != null) builder.and(club.name.eq(clubName));
-        if (status != null) builder.and(cm.status.eq(status));
+        if (status != null) builder.and(club.status.eq(status));
 
         List<ClubMemberDetail> content = queryFactory
                 .selectFrom(cm)

--- a/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
@@ -1,0 +1,20 @@
+package com.example.dgu_semi_erp_back.service.peoplemanagement;
+
+import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.repository.peoplemanagement.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserClubMemberService {
+
+    private final UserQueryRepository queryRepository;
+
+    public Page<ClubMemberDetail> getClubMembers(String clubName, MemberStatus status, Pageable pageable) {
+        return queryRepository.findClubMembers(clubName, status, pageable);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
@@ -1,7 +1,7 @@
 package com.example.dgu_semi_erp_back.service.peoplemanagement;
 
 import com.example.dgu_semi_erp_back.dto.peoplemanagement.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import com.example.dgu_semi_erp_back.repository.peoplemanagement.UserQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,7 +14,7 @@ public class UserClubMemberService {
 
     private final UserQueryRepository queryRepository;
 
-    public Page<ClubMemberDetail> getClubMembers(String clubName, MemberStatus status, Pageable pageable) {
+    public Page<ClubMemberDetail> getClubMembers(String clubName, ClubStatus status, Pageable pageable) {
         return queryRepository.findClubMembers(clubName, status, pageable);
     }
 }


### PR DESCRIPTION
## 🔎 관련 이슈
https://documenter.getpostman.com/view/39135908/2sB2cUB3ek
postman api 참조

## 🔎 작업 내용


1. API 기능 개발
	•	GET /api/users/club-members 엔드포인트 구현
	•	QueryDSL 기반 사용자-클럽 관계 조회
	•	페이지네이션 기능 지원 (page, size)

2. QueryDSL 설정
	•	QuerydslConfig 클래스 작성하여 JPAQueryFactory 빈 등록

3. Mapper 추가
	•	UserClubMemberMapper 인터페이스 작성
	•	UserQueryRepositoryImpl 에서 mapper를 주입받도록 구성

4. 응답 DTO 구성
	•	ClubMemberResponse 등 응답 객체 정의 및 매핑
5. User 엔터티에 major, studentnumber 추가 (전공, 학번)

## 🔎 참고사항
![스크린샷 2025-04-05 오후 9 24 59](https://github.com/user-attachments/assets/07a2fa00-9373-4c53-94ee-298f34088610)


