### PR TITLE
feat: 통장 정보 및 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
@@ -1,9 +1,11 @@
 package com.example.dgu_semi_erp_back.dto.account;
 
 import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
 import lombok.Builder;
 
 import java.time.Instant;
+import java.util.List;
 
 public final class AccountCommandDto {
     private AccountCommandDto() {}
@@ -32,5 +34,14 @@ public final class AccountCommandDto {
     @Builder
     public record AccountUpdateResponse(
             Account account
+    ) {}
+
+    @Builder
+    public record AccountInfoResponse(
+            String number,
+            Instant createdAt,
+            String ownerName,
+            String clubName,
+            List<AccountHistoryDetailResponse> accountHistories
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountHistoryCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountHistoryCommandDto.java
@@ -1,0 +1,33 @@
+package com.example.dgu_semi_erp_back.dto.account;
+
+import com.example.dgu_semi_erp_back.entity.account.PayType;
+import lombok.Builder;
+
+import java.time.Instant;
+
+public final class AccountHistoryCommandDto {
+    private AccountHistoryCommandDto() {}
+
+    @Builder
+    public record AccountHistoryCreateRequest(
+            String content,
+            int totalAmount,
+            int usedAmount
+    ) {}
+
+    @Builder
+    public record AccountHistoryCreateResponse(
+            String content,
+            int totalAmount,
+            int usedAmount
+    ) {}
+
+    @Builder
+    public record AccountHistoryDetailResponse(
+            PayType payType,
+            String content,
+            int usedAmount,
+            int totalAmount,
+            Instant createdAt
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/account/AccountHistory.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/account/AccountHistory.java
@@ -1,12 +1,12 @@
 package com.example.dgu_semi_erp_back.entity.account;
-import com.example.dgu_semi_erp_back.entity.club.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -21,7 +21,7 @@ public class AccountHistory {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role; // 역할 추가
+    private PayType payType;
 
     @Column(nullable = false)
     private String content;
@@ -32,8 +32,9 @@ public class AccountHistory {
     @Column(nullable = false)
     private int usedAmount; // 사용 금액
 
+    @CreatedDate
     @Column(nullable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id", nullable = false)

--- a/src/main/java/com/example/dgu_semi_erp_back/exception/AccountNotFoundException.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/exception/AccountNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.exception;
+
+public class AccountNotFoundException extends RuntimeException {
+    public AccountNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountCommandRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountCommandRepository.java
@@ -3,5 +3,6 @@ package com.example.dgu_semi_erp_back.repository.account;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+// 데이터 생성, 수정, 삭제
 public interface AccountCommandRepository extends JpaRepository<Account, Long> {
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountQueryRepository.java
@@ -3,6 +3,9 @@ package com.example.dgu_semi_erp_back.repository.account;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AccountQueryRepository extends JpaRepository<Account, Long> {
+import java.util.Optional;
 
+// 데이터 조회
+public interface AccountQueryRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findAccountByClubId(Long clubId);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -4,9 +4,11 @@ import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreate
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
 import com.example.dgu_semi_erp_back.mapper.AccountDtoMapper;
+import com.example.dgu_semi_erp_back.repository.account.AccountCommandRepository;
 import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
@@ -21,6 +23,7 @@ import java.time.Instant;
 @Service
 @RequiredArgsConstructor
 public class AccountCommandService implements AccountCreateUseCase {
+    private final AccountCommandRepository accountCommandRepository;
     private final AccountQueryRepository accountQueryRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
@@ -38,6 +41,12 @@ public class AccountCommandService implements AccountCreateUseCase {
 
         Account account = mapper.toEntity(request, user, club, now);
 
-        return accountQueryRepository.save(account);
+        return accountCommandRepository.save(account);
+    }
+
+    @Override
+    public Account getAccountByClubId(Long clubId) {
+        return accountQueryRepository.findAccountByClubId(clubId)
+                .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountQueryService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountQueryService.java
@@ -1,0 +1,9 @@
+package com.example.dgu_semi_erp_back.service.account;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountQueryService {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
@@ -5,4 +5,5 @@ import com.example.dgu_semi_erp_back.entity.account.Account;
 
 public interface AccountCreateUseCase {
     Account create(AccountCreateRequest request);
+    Account getAccountByClubId(Long clubId);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
closed #19 

## 🔎 작업 내용
- 통장 정보 및 내역 조회 API 구현
![스크린샷 2025-04-11 19 43 00](https://github.com/user-attachments/assets/b35fb2dc-7717-42f9-9f5f-a50a096e8075)
- AccountHistory 엔티티 컬럼 변경
   - Role(역할) -> PayType(거래 유형 - 입/출금)
   - 변경 사유: 계좌 내역에 Role(역할) 존재 이유 없음

## 🔎 참고사항
postman api 문서 업데이트
[DGU SEMI ERP API DOCUMENT](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt)
