### PR TITLE
fix: 인원관리 동아리 및 인원 목록조회

### DIFF
--- a/db/config/notification_init.sql
+++ b/db/config/notification_init.sql
@@ -1,0 +1,18 @@
+-- 1. 유저 정보
+INSERT INTO user (id, student_number, major, email, username, password, nickname, role, is_verified)
+VALUES (1, 20240001, '컴퓨터공학과', 'hong@test.com', 'hong', '1234', '홍길동', 'MEMBER', true);
+
+-- 2. 동아리 정보
+INSERT INTO club (club_id, name, affiliation, status, created_at, updated_at)
+VALUES (1, '개발동아리', '공과대학', 'ACTIVE', NOW(), NOW());
+
+-- 3. 가입 정보
+INSERT INTO club_member (id, club_id, user_id, role, status, registered_at)
+VALUES (1, 1, 1, 1, 0, NOW());
+
+-- 4. 알림 데이터 (created_at 3일 이내면 isNew = true)
+INSERT INTO notification (notification_id, title, content, category, created_at, is_read, club_id, user_id)
+VALUES
+    (1, '동아리 가입 승인', '홍길동 님의 가입 요청이 승인되었습니다.', 'CLUB', NOW(), false, 1, 1),
+    (2, '정기 모임 공지', '이번 주 정기 모임은 금요일입니다.', 'CLUB', NOW(), true, 1, 1),
+    (3, '경고', '무단 불참 시 불이익이 있을 수 있습니다.', 'CLUB', DATE_SUB(NOW(), INTERVAL 5 DAY), false, 1, 1);

--- a/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
@@ -1,0 +1,23 @@
+package com.example.dgu_semi_erp_back.controller;
+
+import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.service.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public Page<NotificationResponse> getNotifications(@RequestParam(required = false) String category,
+                                                       @RequestParam Long userId,
+                                                       Pageable pageable) {
+        return notificationService.getNotifications(category, userId, pageable);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
@@ -1,18 +1,22 @@
 package com.example.dgu_semi_erp_back.controller;
 
+import com.example.dgu_semi_erp_back.dto.notification.NotificationCountDto.NotificationCategoryCountResponse;
 import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
 import com.example.dgu_semi_erp_back.service.notification.NotificationService;
+import com.example.dgu_semi_erp_back.service.notification.SseEmitterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notifications")
+@RequestMapping("/notifications")
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final SseEmitterService sseEmitterService;
 
     @GetMapping
     public Page<NotificationResponse> getNotifications(@RequestParam(required = false) String category,
@@ -20,4 +24,15 @@ public class NotificationController {
                                                        Pageable pageable) {
         return notificationService.getNotifications(category, userId, pageable);
     }
+
+    @GetMapping("/subscribe")
+    public SseEmitter subscribe(@RequestParam Long userId) {
+        return sseEmitterService.subscribe(userId);
+    }
+
+    @GetMapping("/category-counts")
+    public NotificationCategoryCountResponse getCategoryCounts(@RequestParam Long userId) {
+        return notificationService.getCategoryCounts(userId);
+    }
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/notification/NotificationCountDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/notification/NotificationCountDto.java
@@ -1,0 +1,15 @@
+package com.example.dgu_semi_erp_back.dto.notification;
+
+import com.example.dgu_semi_erp_back.entity.notification.Category;
+import lombok.Builder;
+
+import java.util.Map;
+
+public final class NotificationCountDto {
+    private NotificationCountDto() {}
+
+    @Builder
+    public record NotificationCategoryCountResponse(
+            Map<Category, Long> categoryCounts
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/notification/NotificationQueryDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/notification/NotificationQueryDto.java
@@ -1,0 +1,21 @@
+package com.example.dgu_semi_erp_back.dto.notification;
+
+import com.example.dgu_semi_erp_back.entity.notification.Category;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public final class NotificationQueryDto {
+    private NotificationQueryDto() {}
+
+    @Builder
+    public record NotificationResponse(
+            Long id,
+            String title,
+            String content,
+            Category category,
+            LocalDateTime date,
+            Boolean read,
+            boolean isNew // 3일 이내 생성된 경우 true
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/notification/Notification.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/notification/Notification.java
@@ -26,6 +26,7 @@ public class Notification {
 
     private String content;
 
+    @Enumerated(EnumType.STRING)
     private Category category;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/NotificationMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/NotificationMapper.java
@@ -1,0 +1,21 @@
+package com.example.dgu_semi_erp_back.mapper;
+
+import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.entity.notification.Notification;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.time.LocalDateTime;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+    @Mapping(target = "date", source = "createdAt")
+    @Mapping(target = "read", source = "isRead")
+    @Mapping(target = "isNew", expression = "java(isNew(notification.getCreatedAt()))")
+    NotificationResponse toDto(Notification notification);
+
+    default boolean isNew(LocalDateTime createdAt) {
+        return createdAt != null && createdAt.isAfter(LocalDateTime.now().minusDays(3));
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.dgu_semi_erp_back.repository.notification;
+
+import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.entity.notification.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationQueryRepository {
+    Page<NotificationResponse> findByCategoryAndUser(Category category, Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepository.java
@@ -5,6 +5,9 @@ import com.example.dgu_semi_erp_back.entity.notification.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Map;
+
 public interface NotificationQueryRepository {
     Page<NotificationResponse> findByCategoryAndUser(Category category, Long userId, Pageable pageable);
+    Map<Category, Long> countByCategoryForUser(Long userId);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.example.dgu_semi_erp_back.repository.notification;
+
+import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.entity.notification.QNotification;
+import com.example.dgu_semi_erp_back.entity.notification.Category;
+import com.example.dgu_semi_erp_back.mapper.NotificationMapper;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepositoryImpl implements NotificationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final NotificationMapper mapper;
+
+    @Override
+    public Page<NotificationResponse> findByCategoryAndUser(Category category, Long userId, Pageable pageable) {
+        QNotification notification = QNotification.notification;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        if (category != null) builder.and(notification.category.eq(category));
+        if (userId != null) builder.and(notification.user.id.eq(userId));
+
+        List<NotificationResponse> content = queryFactory
+                .selectFrom(notification)
+                .where(builder)
+                .orderBy(notification.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+
+        Long count = queryFactory
+                .select(notification.count())
+                .from(notification)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.example.dgu_semi_erp_back.entity.notification.QNotification;
 import com.example.dgu_semi_erp_back.entity.notification.Category;
 import com.example.dgu_semi_erp_back.mapper.NotificationMapper;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -47,4 +50,23 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
 
         return new PageImpl<>(content, pageable, count != null ? count : 0);
     }
+
+    @Override
+    public Map<Category, Long> countByCategoryForUser(Long userId) {
+        QNotification notification = QNotification.notification;
+
+        List<Tuple> results = queryFactory
+            .select(notification.category, notification.count())
+            .from(notification)
+            .where(notification.user.id.eq(userId))
+            .groupBy(notification.category)
+            .fetch();
+
+        return results.stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(notification.category),
+                tuple -> tuple.get(notification.count())
+            ));
+    }
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
@@ -4,9 +4,12 @@ import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.Notif
 import com.example.dgu_semi_erp_back.entity.notification.Category;
 import com.example.dgu_semi_erp_back.mapper.NotificationMapper;
 import com.example.dgu_semi_erp_back.repository.notification.NotificationQueryRepository;
+import com.example.dgu_semi_erp_back.dto.notification.NotificationCountDto.NotificationCategoryCountResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -27,5 +30,12 @@ public class NotificationService {
                 notificationQueryRepository.findByCategoryAndUser(category, userId, pageable);
 
         return page;
+    }
+
+    public NotificationCategoryCountResponse getCategoryCounts(Long userId) {
+        Map<Category, Long> counts = notificationQueryRepository.countByCategoryForUser(userId);
+        return NotificationCategoryCountResponse.builder()
+                .categoryCounts(counts)
+                .build();
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
@@ -1,0 +1,31 @@
+package com.example.dgu_semi_erp_back.service.notification;
+
+import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.entity.notification.Category;
+import com.example.dgu_semi_erp_back.mapper.NotificationMapper;
+import com.example.dgu_semi_erp_back.repository.notification.NotificationQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationQueryRepository notificationQueryRepository;
+    private final NotificationMapper mapper;
+
+    public Page<NotificationResponse> getNotifications(String categoryName, Long userId, Pageable pageable) {
+        Category category = null;
+        if (categoryName != null) {
+            try {
+                category = Category.valueOf(categoryName.toUpperCase());
+            } catch (IllegalArgumentException ignored) {}
+        }
+
+        Page<NotificationResponse> page =
+                notificationQueryRepository.findByCategoryAndUser(category, userId, pageable);
+
+        return page;
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/notification/SseEmitterService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/notification/SseEmitterService.java
@@ -1,0 +1,43 @@
+package com.example.dgu_semi_erp_back.service.notification;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SseEmitterService {
+    private static final Long TIMEOUT = 60L * 1000 * 60; // 1시간
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitters.put(userId, emitter);
+
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        emitter.onError((e) -> emitters.remove(userId));
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    public void sendNotification(Long userId, Object data) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().name("notification").data(data));
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+                emitters.remove(userId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 관련 이슈

	•	알림 기능 구현 (#notification-api)
	•	사용자별, 카테고리별 알림 페이징 조회 필요
	•	3일 이내 생성된 알림은 isNew: true 처리

## 🔎 작업 내용

	•	/api/notifications GET API 구현
→ category + userId + pageable 파라미터로 알림 조회
	•	NotificationService, NotificationQueryRepository 개선
→ findByCategoryAndUser(Category, Long, Pageable) 기준 쿼리 수행
	•	NotificationResponse DTO에 isNew 로직 포함
→ createdAt 기준 3일 이내 판단
	•	notification_init.sql 스크립트 작성 및 Docker 연동
→ 서버 최초 구동 시 테스트용 알림, 유저, 동아리 자동 생성
	•	Postman으로 API 테스트 및 응답 구조 확인 완료
문서화 알수 없는 오류로 실패.. 원인 찾아봐야함

## 🔎 참고사항
![스크린샷 2025-04-12 오후 8 22 15](https://github.com/user-attachments/assets/768d927b-2842-4f30-9452-432b74fa6ded)
