### PR TITLE
update: 통장 정보 및 상세 내역 api 페이지네이션 추가 & 통장 정보 변경 api 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
@@ -1,6 +1,8 @@
 package com.example.dgu_semi_erp_back.api.account;
 
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdateRequest;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountInfoResponse;
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountInfoDetailResponse;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateResponse;
 import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
@@ -8,11 +10,9 @@ import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
 import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
-import com.example.dgu_semi_erp_back.usecase.account.AccountCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.account.AccountUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +22,14 @@ import org.springframework.web.server.ResponseStatusException;
  * 통장관리 API
  * @author 권민지
  * @since 2025.04.05
- * @LastModified 2025.04.11
+ * @LastModified 2025.04.19
  */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/account")
 @Validated
 public class AccountApi {
-    private final AccountCreateUseCase accountCreateUseCase;
+    private final AccountUseCase accountUseCase;
 
     /**
      * 통장 개설
@@ -42,7 +42,7 @@ public class AccountApi {
             @RequestBody @Valid AccountCreateRequest request
     ){
         try {
-            var account = accountCreateUseCase.create(request);
+            var account = accountUseCase.create(request);
 
             return AccountCreateResponse.builder()
                     .account(account)
@@ -57,20 +57,20 @@ public class AccountApi {
     /**
      * 통장 정보 조회
      * @param clubId 동아리 ID
-     * @return AccountInfoResponse 통장 번호, 개설일, 소유주 이름, 동아리 이름, (List)통장 거래 내역
+     * @return AccountInfoResponse 통장 번호, 개설일, 소유주 이름, 동아리 이름, (List)통장 거래 내역, PaginationInfo
      */
     @GetMapping("/{clubId}")
     @ResponseStatus(HttpStatus.OK)
-    public AccountInfoResponse getAccountWithHistories(
+    public AccountInfoDetailResponse getAccountWithHistories(
             @PathVariable("clubId") Long clubId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "7") int size
             ) {
         try {
-            var account = accountCreateUseCase.getAccountByClubId(clubId);
-            var pagedHistories = accountCreateUseCase.getPagedAccountHistories(account.getId(), page, size);
+            var account = accountUseCase.getAccountByClubId(clubId);
+            var pagedHistories = accountUseCase.getPagedAccountHistories(account.getId(), page, size);
 
-            return AccountInfoResponse.builder()
+            return AccountInfoDetailResponse.builder()
                     .number(account.getNumber())
                     .createdAt(account.getCreatedAt())
                     .ownerName(account.getUser().getUsername())
@@ -92,6 +92,33 @@ public class AccountApi {
                     ))
                     .build();
         } catch (ClubNotFoundException | AccountNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    /**
+     * 통장 정보 변경
+     * @param accountId 통장 ID
+     * @param request 통장 번호, 개설일, 동아리 이름, 소유주 이름
+     * @return Account
+     */
+    @PutMapping("/{accountId}")
+    @ResponseStatus(HttpStatus.OK)
+    public AccountInfoResponse updateAccount(
+            @PathVariable("accountId") Long accountId,
+            @RequestBody @Valid AccountUpdateRequest request
+    ) {
+        try {
+            var account = accountUseCase.updateAccount(accountId, request);
+
+            return AccountInfoResponse.builder()
+                    .number(account.getNumber())
+                    .createdAt(account.getCreatedAt())
+                    .updatedAt(account.getUpdatedAt())
+                    .ownerName(account.getUser().getUsername())
+                    .clubName(account.getClub().getName())
+                    .build();
+        } catch (AccountNotFoundException | UserNotFoundException | ClubNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
@@ -1,5 +1,6 @@
 package com.example.dgu_semi_erp_back.dto.account;
 
+import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
 import lombok.Builder;
@@ -42,6 +43,7 @@ public final class AccountCommandDto {
             Instant createdAt,
             String ownerName,
             String clubName,
-            List<AccountHistoryDetailResponse> accountHistories
+            List<AccountHistoryDetailResponse> accountHistories,
+            PaginationInfo paginationInfo
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
@@ -3,6 +3,7 @@ package com.example.dgu_semi_erp_back.dto.account;
 import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.Instant;
@@ -26,19 +27,25 @@ public final class AccountCommandDto {
 
     @Builder
     public record AccountUpdateRequest(
+            @NotNull
             String number,
-            Instant updatedAt,
+            @NotNull
             long userId,
+            @NotNull
             long clubId
     ) {}
 
     @Builder
-    public record AccountUpdateResponse(
-            Account account
+    public record AccountInfoResponse(
+            String number,
+            Instant createdAt,
+            Instant updatedAt,
+            String ownerName,
+            String clubName
     ) {}
 
     @Builder
-    public record AccountInfoResponse(
+    public record AccountInfoDetailResponse(
             String number,
             Instant createdAt,
             String ownerName,

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/common/PaginationInfo.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/common/PaginationInfo.java
@@ -1,0 +1,13 @@
+package com.example.dgu_semi_erp_back.dto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PaginationInfo {
+    private int currentPage;
+    private int pageSize;
+    private int totalPages;
+    private long totalElements;
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountHistoryQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountHistoryQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.dgu_semi_erp_back.repository.account;
+
+import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
+import org.springframework.data.domain.Page;
+
+import org.springframework.data.domain.Pageable;
+
+public interface AccountHistoryQueryRepository {
+    Page<AccountHistory> findPagedHistoriesByAccountId(Long accountId, Pageable pageable);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountHistoryQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/account/AccountHistoryQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.example.dgu_semi_erp_back.repository.account;
+
+import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
+import com.example.dgu_semi_erp_back.entity.account.QAccountHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Repository;
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class AccountHistoryQueryRepositoryImpl implements AccountHistoryQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AccountHistory> findPagedHistoriesByAccountId(Long accountId, Pageable pageable) {
+        QAccountHistory accountHistory = QAccountHistory.accountHistory;
+
+        List<AccountHistory> content = queryFactory.selectFrom(accountHistory)
+                .where(accountHistory.account.id.eq(accountId))
+                .orderBy(accountHistory.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalResult = queryFactory
+                .select(accountHistory.count())
+                .from(accountHistory)
+                .where(accountHistory.account.id.eq(accountId))
+                .fetchOne();
+
+        long total = totalResult != null ? totalResult : 0L;
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -2,6 +2,7 @@ package com.example.dgu_semi_erp_back.service.account;
 
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
@@ -9,12 +10,16 @@ import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
 import com.example.dgu_semi_erp_back.mapper.AccountDtoMapper;
 import com.example.dgu_semi_erp_back.repository.account.AccountCommandRepository;
+import com.example.dgu_semi_erp_back.repository.account.AccountHistoryQueryRepository;
 import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.usecase.account.AccountCreateUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -25,6 +30,7 @@ import java.time.Instant;
 public class AccountCommandService implements AccountCreateUseCase {
     private final AccountCommandRepository accountCommandRepository;
     private final AccountQueryRepository accountQueryRepository;
+    private final AccountHistoryQueryRepository accountHistoryQueryRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
     private final AccountDtoMapper mapper;
@@ -48,5 +54,11 @@ public class AccountCommandService implements AccountCreateUseCase {
     public Account getAccountByClubId(Long clubId) {
         return accountQueryRepository.findAccountByClubId(clubId)
                 .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
+    }
+
+    @Override
+    public Page<AccountHistory> getPagedAccountHistories(Long accountId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return accountHistoryQueryRepository.findPagedHistoriesByAccountId(accountId, pageable);
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -3,6 +3,7 @@ package com.example.dgu_semi_erp_back.service.account;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
+import com.example.dgu_semi_erp_back.entity.account.QAccount;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
@@ -14,7 +15,11 @@ import com.example.dgu_semi_erp_back.repository.account.AccountHistoryQueryRepos
 import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
-import com.example.dgu_semi_erp_back.usecase.account.AccountCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.account.AccountUseCase;
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdateRequest;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,12 +32,13 @@ import java.time.Instant;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AccountCommandService implements AccountCreateUseCase {
+public class AccountCommandService implements AccountUseCase {
     private final AccountCommandRepository accountCommandRepository;
     private final AccountQueryRepository accountQueryRepository;
     private final AccountHistoryQueryRepository accountHistoryQueryRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
+    private final EntityManager entityManager;
     private final AccountDtoMapper mapper;
 
     @Override
@@ -60,5 +66,38 @@ public class AccountCommandService implements AccountCreateUseCase {
     public Page<AccountHistory> getPagedAccountHistories(Long accountId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return accountHistoryQueryRepository.findPagedHistoriesByAccountId(accountId, pageable);
+    }
+
+    @Transactional
+    @Override
+    public Account updateAccount(
+            Long accountId,
+            AccountUpdateRequest request
+    ) {
+        Account account = accountQueryRepository.findById(accountId)
+                .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
+
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
+
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new UserNotFoundException("해당 사용자가 존재하지 않습니다."));
+
+        QAccount qAccount = QAccount.account;
+
+        long updatedCount = new JPAUpdateClause(entityManager, qAccount)
+                .where(qAccount.id.eq(accountId))
+                .set(qAccount.number, request.number())
+                .set(qAccount.club.id, club.getId())
+                .set(qAccount.user.id, user.getId())
+                .set(qAccount.updatedAt, Instant.now())
+                .execute();
+
+        if (updatedCount == 0) {
+            throw new AccountNotFoundException("해당 통장이 존재하지 않습니다.");
+        }
+
+        return accountQueryRepository.findById(accountId)
+                .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountCreateUseCase.java
@@ -2,8 +2,15 @@ package com.example.dgu_semi_erp_back.usecase.account;
 
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
+import org.springframework.data.domain.Page;
 
 public interface AccountCreateUseCase {
     Account create(AccountCreateRequest request);
     Account getAccountByClubId(Long clubId);
+    Page<AccountHistory> getPagedAccountHistories(
+            Long accountId,
+            int page,
+            int size
+    );
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
@@ -1,16 +1,21 @@
 package com.example.dgu_semi_erp_back.usecase.account;
 
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdateRequest;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
 import org.springframework.data.domain.Page;
 
-public interface AccountCreateUseCase {
+public interface AccountUseCase {
     Account create(AccountCreateRequest request);
     Account getAccountByClubId(Long clubId);
     Page<AccountHistory> getPagedAccountHistories(
             Long accountId,
             int page,
             int size
+    );
+    Account updateAccount(
+            Long accountId,
+            AccountUpdateRequest request
     );
 }


### PR DESCRIPTION
## 🔎 관련 이슈
closed #24 
closed #26 

## 🔎 작업 내용
- `getAccountWithHistories` API 페이지네이션 추가
![스크린샷 2025-04-19 18 18 13](https://github.com/user-attachments/assets/836630cd-11e2-44a8-8ffc-2ab71c982e08)
![스크린샷 2025-04-19 18 17 41](https://github.com/user-attachments/assets/5606529c-6540-4f4f-b563-f8d2809b9f4b)

- 통장 정보 변경 API 구현
![스크린샷 2025-04-19 19 00 53](https://github.com/user-attachments/assets/cd53e2be-4548-473d-a72c-cddaeeab743c)
![스크린샷 2025-04-19 19 01 08](https://github.com/user-attachments/assets/a1296d39-25b1-484c-8146-08052ad45411)


### API:
- `AccountApi` `getAccountWithHistories`: 페이지네이션을 위한 `page`, `size` 쿼리 매개변수 추가

### DTO:
- `AccountInfoResponse`: 페이지네이션 메타데이터를 위한 새로운 `PaginationInfo` 필드 추가
- `PaginationInfo` 클래스 생성: 현재 페이지, 페이지 크기, 총 페이지 수, 총 요소 수와 같은 페이지네이션 세부 정보 캡슐화.

### Repository:
- `AccountHistoryQueryRepository` 구현체 생성: QueryDSL을 사용한 통장 내역에 대한 페이지네이션 쿼리 구현

### Service:
- `AccountCommandService`: `getPagedAccountHistories` 메서드 추가

## 🔎 참고사항
[API 문서 업데이트](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt)

실수로 브랜치를 못바꾸고 push해서 해당 PR에 두개의 작업이 병합되었습니다.. 
다음부터는 주의하겠습니다 ㅠㅠ