### PR TITLE
feat: 일정 관리 API 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
@@ -8,6 +8,7 @@ import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByClubIdUseCase;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByMonthUseCase;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleDeleteUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class ScheduleApi {
     private final ScheduleCreateUseCase scheduleCreateUseCase;
     private final ScheduleUpdateUseCase scheduleUpdateUseCase;
+    private final ScheduleDeleteUseCase scheduleDeleteUseCase;
     private final ScheduleFindByClubIdUseCase scheduleFindByClubIdUseCase;
     private final ScheduleFindByMonthUseCase scheduleFindByMonthUseCase;
 
@@ -111,6 +113,18 @@ public class ScheduleApi {
         } catch (ScheduleNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void ScheduleDeleteResponse(
+            @PathVariable Long id
+    ) {
+        try {
+            scheduleDeleteUseCase.delete(id);
+        } catch (ScheduleNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }

--- a/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
@@ -1,9 +1,12 @@
 package com.example.dgu_semi_erp_back.api.schedule;
 
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleQueryDto.*;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.ScheduleNotFoundException;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByClubIdUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByMonthUseCase;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,8 @@ import org.springframework.web.server.ResponseStatusException;
 public class ScheduleApi {
     private final ScheduleCreateUseCase scheduleCreateUseCase;
     private final ScheduleUpdateUseCase scheduleUpdateUseCase;
+    private final ScheduleFindByClubIdUseCase scheduleFindByClubIdUseCase;
+    private final ScheduleFindByMonthUseCase scheduleFindByMonthUseCase;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -62,6 +67,46 @@ public class ScheduleApi {
                     .repeat(updatedSchedule.getRepeat())
                     .build();
 
+
+        } catch (ScheduleNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @GetMapping("/{club_id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ScheduleListResponse findByClubId(
+            @PathVariable("club_id") Long clubId
+    ) {
+        try {
+            var schedules = scheduleFindByClubIdUseCase.findByClubId(clubId);
+
+            return ScheduleListResponse.builder()
+                    .scheduleList(schedules)
+                    .build();
+
+        } catch (ScheduleNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ScheduleListResponse findByMonth(
+            @RequestParam("club_id") Long clubId,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ) {
+        try {
+            var schedules = scheduleFindByMonthUseCase.findByMonth(clubId, year, month);
+
+            return ScheduleListResponse.builder()
+                    .scheduleList(schedules)
+                    .build();
 
         } catch (ScheduleNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());

--- a/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
@@ -1,0 +1,44 @@
+package com.example.dgu_semi_erp_back.api.schedule;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
+import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/schedule")
+@Validated
+
+public class ScheduleApi {
+    private final ScheduleCreateUseCase scheduleCreateUseCase;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ScheduleCreateResponse create(
+            @RequestBody @Valid ScheduleCreateRequest request
+    ) {
+        try {
+            var schedule = scheduleCreateUseCase.create(request);
+
+            return ScheduleCreateResponse.builder()
+                    .clubId(schedule.getClub().getId())
+                    .title(schedule.getTitle())
+                    .date(schedule.getDate())
+                    .place(schedule.getPlace())
+                    .repeat(schedule.getRepeat())
+                    .build();
+
+        } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
@@ -2,7 +2,9 @@ package com.example.dgu_semi_erp_back.api.schedule;
 
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.exception.ScheduleNotFoundException;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class ScheduleApi {
     private final ScheduleCreateUseCase scheduleCreateUseCase;
+    private final ScheduleUpdateUseCase scheduleUpdateUseCase;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -41,4 +44,29 @@ public class ScheduleApi {
 
     }
 
+    @PutMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ScheduleUpdateResponse update(
+            @PathVariable Long id,
+            @RequestBody @Valid ScheduleUpdateRequest request
+    ) {
+
+        try{
+            var updatedSchedule = scheduleUpdateUseCase.update(id, request);
+
+            return ScheduleUpdateResponse.builder()
+                    .clubId(updatedSchedule.getClub().getId())
+                    .title(updatedSchedule.getTitle())
+                    .date(updatedSchedule.getDate())
+                    .place(updatedSchedule.getPlace())
+                    .repeat(updatedSchedule.getRepeat())
+                    .build();
+
+
+        } catch (ScheduleNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (ClubNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/schedule/ScheduleApi.java
@@ -12,6 +12,7 @@ import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleDeleteUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -31,19 +32,14 @@ public class ScheduleApi {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ScheduleCreateResponse create(
+    public ResponseEntity<MessageResponse> create(
             @RequestBody @Valid ScheduleCreateRequest request
     ) {
         try {
             var schedule = scheduleCreateUseCase.create(request);
 
-            return ScheduleCreateResponse.builder()
-                    .clubId(schedule.getClub().getId())
-                    .title(schedule.getTitle())
-                    .date(schedule.getDate())
-                    .place(schedule.getPlace())
-                    .repeat(schedule.getRepeat())
-                    .build();
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(new MessageResponse("일정이 추가되었습니다."));
 
         } catch (ClubNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
@@ -53,7 +49,7 @@ public class ScheduleApi {
 
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ScheduleUpdateResponse update(
+    public ResponseEntity<MessageResponse> update(
             @PathVariable Long id,
             @RequestBody @Valid ScheduleUpdateRequest request
     ) {
@@ -61,13 +57,7 @@ public class ScheduleApi {
         try{
             var updatedSchedule = scheduleUpdateUseCase.update(id, request);
 
-            return ScheduleUpdateResponse.builder()
-                    .clubId(updatedSchedule.getClub().getId())
-                    .title(updatedSchedule.getTitle())
-                    .date(updatedSchedule.getDate())
-                    .place(updatedSchedule.getPlace())
-                    .repeat(updatedSchedule.getRepeat())
-                    .build();
+            return ResponseEntity.ok(new MessageResponse("일정이 수정되었습니다."));
 
 
         } catch (ScheduleNotFoundException e) {

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
@@ -5,7 +5,7 @@ import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
-import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
+import com.example.dgu_semi_erp_back.repository.schedule.ScheduleCommandRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,11 +17,11 @@ import java.time.LocalDateTime;
 public class DummyDataConfig {
 
     private final ClubRepository clubRepository;
-    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final ScheduleCommandRepository scheduleCommandRepository;
 
-    public DummyDataConfig(ClubRepository clubRepository, ScheduleQueryRepository scheduleQueryRepository) {
+    public DummyDataConfig(ClubRepository clubRepository, ScheduleCommandRepository scheduleCommandRepository) {
         this.clubRepository = clubRepository;
-        this.scheduleQueryRepository = scheduleQueryRepository;
+        this.scheduleCommandRepository = scheduleCommandRepository;
     }
 
     @Bean
@@ -40,7 +40,7 @@ public class DummyDataConfig {
     }
 
     @Bean
-    CommandLineRunner initScheduleData(ScheduleQueryRepository scheduleQueryRepository) {
+    CommandLineRunner initScheduleData(ScheduleCommandRepository scheduleCommandRepository) {
         return args -> {
             Schedule schedule = Schedule.builder()
                     .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
@@ -51,12 +51,12 @@ public class DummyDataConfig {
                     .createdAt(Instant.now())
                     .build();
 
-            scheduleQueryRepository.save(schedule);
+            scheduleCommandRepository.save(schedule);
         };
     }
 
     @Bean
-    CommandLineRunner initScheduleData2(ScheduleQueryRepository scheduleQueryRepository) {
+    CommandLineRunner initScheduleData2(ScheduleCommandRepository scheduleCommandRepository) {
         return args -> {
             Schedule schedule = Schedule.builder()
                     .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
@@ -67,12 +67,12 @@ public class DummyDataConfig {
                     .createdAt(Instant.now())
                     .build();
 
-            scheduleQueryRepository.save(schedule);
+            scheduleCommandRepository.save(schedule);
         };
     }
 
     @Bean
-    CommandLineRunner initScheduleData3(ScheduleQueryRepository scheduleQueryRepository) {
+    CommandLineRunner initScheduleData3(ScheduleCommandRepository scheduleCommandRepository) {
         return args -> {
             Schedule schedule = Schedule.builder()
                     .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
@@ -83,7 +83,7 @@ public class DummyDataConfig {
                     .createdAt(Instant.now())
                     .build();
 
-            scheduleQueryRepository.save(schedule);
+            scheduleCommandRepository.save(schedule);
         };
     }
 

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
@@ -25,7 +25,7 @@ public class DummyDataConfig {
     }
 
     @Bean
-    CommandLineRunner initClubData(ClubRepository clubRepository) {
+    CommandLineRunner initData() {
         return args -> {
             Club club = Club.builder()
                     .name("디벨로퍼")
@@ -35,55 +35,40 @@ public class DummyDataConfig {
                     .updatedAt(LocalDateTime.now())
                     .build();
 
-            clubRepository.save(club);
-        };
-    }
+            Club savedClub = clubRepository.save(club);
 
-    @Bean
-    CommandLineRunner initScheduleData(ScheduleCommandRepository scheduleCommandRepository) {
-        return args -> {
-            Schedule schedule = Schedule.builder()
-                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
-                    .title("정기모임")
-                    .date(LocalDateTime.of(2025, 2, 17, 10, 30))
-                    .place("공대 101호")
-                    .repeat(ScheduleRepeat.WEEKLY)
-                    .createdAt(Instant.now())
-                    .build();
+            scheduleCommandRepository.save(
+                    Schedule.builder()
+                            .club(savedClub)
+                            .title("정기모임")
+                            .date(LocalDateTime.of(2025, 2, 17, 10, 30))
+                            .place("공대 101호")
+                            .repeat(ScheduleRepeat.WEEKLY)
+                            .createdAt(Instant.now())
+                            .build()
+            );
 
-            scheduleCommandRepository.save(schedule);
-        };
-    }
+            scheduleCommandRepository.save(
+                    Schedule.builder()
+                            .club(savedClub)
+                            .title("정기모임2")
+                            .date(LocalDateTime.of(2025, 3, 17, 10, 30))
+                            .place("공대 101호")
+                            .repeat(ScheduleRepeat.WEEKLY)
+                            .createdAt(Instant.now())
+                            .build()
+            );
 
-    @Bean
-    CommandLineRunner initScheduleData2(ScheduleCommandRepository scheduleCommandRepository) {
-        return args -> {
-            Schedule schedule = Schedule.builder()
-                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
-                    .title("정기모임2")
-                    .date(LocalDateTime.of(2025, 3, 17, 10, 30))
-                    .place("공대 101호")
-                    .repeat(ScheduleRepeat.WEEKLY)
-                    .createdAt(Instant.now())
-                    .build();
-
-            scheduleCommandRepository.save(schedule);
-        };
-    }
-
-    @Bean
-    CommandLineRunner initScheduleData3(ScheduleCommandRepository scheduleCommandRepository) {
-        return args -> {
-            Schedule schedule = Schedule.builder()
-                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
-                    .title("정기모임3")
-                    .date(LocalDateTime.of(2025, 4, 17, 10, 30))
-                    .place("공대 101호")
-                    .repeat(ScheduleRepeat.WEEKLY)
-                    .createdAt(Instant.now())
-                    .build();
-
-            scheduleCommandRepository.save(schedule);
+            scheduleCommandRepository.save(
+                    Schedule.builder()
+                            .club(savedClub)
+                            .title("정기모임3")
+                            .date(LocalDateTime.of(2025, 4, 17, 10, 30))
+                            .place("공대 101호")
+                            .repeat(ScheduleRepeat.WEEKLY)
+                            .createdAt(Instant.now())
+                            .build()
+            );
         };
     }
 

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
@@ -1,0 +1,30 @@
+package com.example.dgu_semi_erp_back.common.config;
+
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+@Configuration
+public class DummyDataConfig {
+
+    @Bean
+    CommandLineRunner initClubData(ClubRepository clubRepository) {
+        return args -> {
+            Club club = Club.builder()
+                    .name("디벨로퍼")
+                    .affiliation("공대")
+                    .status(MemberStatus.ACTIVE)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            clubRepository.save(club);
+        };
+    }
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
@@ -2,15 +2,27 @@ package com.example.dgu_semi_erp_back.common.config;
 
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
+import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Configuration
 public class DummyDataConfig {
+
+    private final ClubRepository clubRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+
+    public DummyDataConfig(ClubRepository clubRepository, ScheduleQueryRepository scheduleQueryRepository) {
+        this.clubRepository = clubRepository;
+        this.scheduleQueryRepository = scheduleQueryRepository;
+    }
 
     @Bean
     CommandLineRunner initClubData(ClubRepository clubRepository) {
@@ -24,6 +36,54 @@ public class DummyDataConfig {
                     .build();
 
             clubRepository.save(club);
+        };
+    }
+
+    @Bean
+    CommandLineRunner initScheduleData(ScheduleQueryRepository scheduleQueryRepository) {
+        return args -> {
+            Schedule schedule = Schedule.builder()
+                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
+                    .title("정기모임")
+                    .date(LocalDateTime.of(2025, 2, 17, 10, 30))
+                    .place("공대 101호")
+                    .repeat(ScheduleRepeat.WEEKLY)
+                    .createdAt(Instant.now())
+                    .build();
+
+            scheduleQueryRepository.save(schedule);
+        };
+    }
+
+    @Bean
+    CommandLineRunner initScheduleData2(ScheduleQueryRepository scheduleQueryRepository) {
+        return args -> {
+            Schedule schedule = Schedule.builder()
+                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
+                    .title("정기모임2")
+                    .date(LocalDateTime.of(2025, 3, 17, 10, 30))
+                    .place("공대 101호")
+                    .repeat(ScheduleRepeat.WEEKLY)
+                    .createdAt(Instant.now())
+                    .build();
+
+            scheduleQueryRepository.save(schedule);
+        };
+    }
+
+    @Bean
+    CommandLineRunner initScheduleData3(ScheduleQueryRepository scheduleQueryRepository) {
+        return args -> {
+            Schedule schedule = Schedule.builder()
+                    .club(clubRepository.findById(1L).orElseThrow(() -> new RuntimeException("Club not found")))
+                    .title("정기모임3")
+                    .date(LocalDateTime.of(2025, 4, 17, 10, 30))
+                    .place("공대 101호")
+                    .repeat(ScheduleRepeat.WEEKLY)
+                    .createdAt(Instant.now())
+                    .build();
+
+            scheduleQueryRepository.save(schedule);
         };
     }
 

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/WebConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.example.dgu_semi_erp_back.common.config;
 import com.example.dgu_semi_erp_back.common.jwt.JwtInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -14,5 +15,14 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/post/**"); // JWT 인가가 필요한 경로 설정
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 요청 허용
+                .allowedOrigins("http://localhost:3000") // 프론트 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true); // 쿠키/인증정보 포함시 필요
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
@@ -45,6 +45,12 @@ public class ScheduleCommandDto {
 
     @Builder
     public record ScheduleUpdateResponse(
-            Schedule schedule
+            @JsonProperty("club_id")
+            Long clubId,
+
+            String title,
+            LocalDateTime date,
+            String place,
+            ScheduleRepeat repeat
     ){}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
@@ -36,7 +36,6 @@ public class ScheduleCommandDto {
 
     @Builder
     public record ScheduleUpdateRequest(
-            Long id,
             String title,
             LocalDateTime date,
             String place,
@@ -53,4 +52,6 @@ public class ScheduleCommandDto {
             String place,
             ScheduleRepeat repeat
     ){}
+
+    public record MessageResponse(String message) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleCommandDto.java
@@ -1,0 +1,50 @@
+package com.example.dgu_semi_erp_back.dto.schedule;
+
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+public class ScheduleCommandDto {
+
+
+    @Builder
+    public record ScheduleCreateRequest(
+            @JsonProperty("club_id")
+            Long clubId,
+
+            String title,
+            LocalDateTime date,
+            String place,
+            ScheduleRepeat repeat
+    ){}
+
+    @Builder
+    public record ScheduleCreateResponse(
+            @JsonProperty("club_id")
+            Long clubId,
+
+            String title,
+            LocalDateTime date,
+            String place,
+            ScheduleRepeat repeat
+    ){}
+
+    @Builder
+    public record ScheduleUpdateRequest(
+            Long id,
+            String title,
+            LocalDateTime date,
+            String place,
+            ScheduleRepeat repeat
+    ){}
+
+    @Builder
+    public record ScheduleUpdateResponse(
+            Schedule schedule
+    ){}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
@@ -20,8 +20,6 @@ public class ScheduleQueryDto {
 
     @Builder
     public record ScheduleListResponse(
-            @JsonProperty("club_id")
-            Long clubId,
             List<ScheduleDetail> scheduleList
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
@@ -1,4 +1,27 @@
 package com.example.dgu_semi_erp_back.dto.schedule;
 
+import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ScheduleQueryDto {
+
+    @Builder
+    public record ScheduleDetail(
+            Long id,
+            String title,
+            LocalDateTime date,
+            String place,
+            ScheduleRepeat repeat
+    ) {}
+
+    @Builder
+    public record ScheduleListResponse(
+            @JsonProperty("club_id")
+            Long clubId,
+            List<ScheduleDetail> scheduleList
+    ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/schedule/ScheduleQueryDto.java
@@ -1,0 +1,4 @@
+package com.example.dgu_semi_erp_back.dto.schedule;
+
+public class ScheduleQueryDto {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/club/Club.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/club/Club.java
@@ -1,5 +1,6 @@
 package com.example.dgu_semi_erp_back.entity.club;
 import com.example.dgu_semi_erp_back.entity.account.Account;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,4 +42,7 @@ public class Club {
 
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ClubMember> clubMembers;
+
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Schedule> schedules;
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
@@ -1,0 +1,50 @@
+package com.example.dgu_semi_erp_back.entity.schedule;
+
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+
+public class Schedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "date", nullable = false)
+    private Instant date;
+
+    @Column(name = "place", nullable = false)
+    private String place;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "repeat", nullable = true)
+    private ScheduleRepeat repeat;
+
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
@@ -47,5 +47,12 @@ public class Schedule {
     @Column(name = "schedule_repeat", nullable = true)
     private ScheduleRepeat repeat;
 
+    public void update(String title, LocalDateTime date, String place, ScheduleRepeat repeat) {
+        this.title = title;
+        this.date = date;
+        this.place = place;
+        this.repeat = repeat;
+    }
+
 
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/Schedule.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import jakarta.persistence.*;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -37,13 +38,13 @@ public class Schedule {
     private String title;
 
     @Column(name = "date", nullable = false)
-    private Instant date;
+    private LocalDateTime date;
 
     @Column(name = "place", nullable = false)
     private String place;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "repeat", nullable = true)
+    @Column(name = "schedule_repeat", nullable = true)
     private ScheduleRepeat repeat;
 
 

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/type/ScheduleRepeat.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/type/ScheduleRepeat.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.entity.schedule.type;
+
+public enum ScheduleRepeat {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/type/ScheduleRepeat.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/schedule/type/ScheduleRepeat.java
@@ -1,7 +1,14 @@
 package com.example.dgu_semi_erp_back.entity.schedule.type;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ScheduleRepeat {
-    DAILY,
-    WEEKLY,
-    MONTHLY,
+    DAILY("매일"),
+    WEEKLY("매주"),
+    MONTHLY("매월");
+
+    private final String description;
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/exception/ScheduleNotFoundException.java
@@ -1,0 +1,5 @@
+package com.example.dgu_semi_erp_back.exception;
+
+public class ScheduleNotFoundException extends RuntimeException {
+    public ScheduleNotFoundException(String message) { super(message); }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
@@ -6,6 +6,7 @@ import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 import java.time.Instant;
 
@@ -20,6 +21,5 @@ public interface ScheduleDtoMapper {
             Club club,
             Instant createdAt
     );
-
 
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
@@ -1,6 +1,7 @@
 package com.example.dgu_semi_erp_back.mapper;
 
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleQueryDto.*;
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
@@ -9,6 +10,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import java.time.Instant;
+import java.util.List;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
@@ -21,5 +23,7 @@ public interface ScheduleDtoMapper {
             Club club,
             Instant createdAt
     );
+
+    List<ScheduleDetail> toScheduleDetailList(List<Schedule> schedules);
 
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/ScheduleDtoMapper.java
@@ -1,0 +1,25 @@
+package com.example.dgu_semi_erp_back.mapper;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.time.Instant;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING)
+public interface ScheduleDtoMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", source = "createdAt")
+    Schedule toEntity(
+            ScheduleCreateRequest dto,
+            Club club,
+            Instant createdAt
+    );
+
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleCommandRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleCommandRepository.java
@@ -1,0 +1,11 @@
+package com.example.dgu_semi_erp_back.repository.schedule;
+
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ScheduleCommandRepository extends JpaRepository<Schedule, Long> {
+
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.dgu_semi_erp_back.repository.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+
+import java.util.List;
+
+public interface ScheduleQueryRepository extends JpaRepository<Schedule, Long> {
+    List<Schedule> findByClubId(Long clubId);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/schedule/ScheduleQueryRepository.java
@@ -3,8 +3,10 @@ package com.example.dgu_semi_erp_back.repository.schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleQueryRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByClubId(Long clubId);
+    List<Schedule> findByClubIdAndDateBetween(Long clubId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
@@ -1,0 +1,37 @@
+package com.example.dgu_semi_erp_back.service.schedule;
+
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.mapper.ScheduleDtoMapper;
+import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
+import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
+import lombok.Locked;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleCommandService implements ScheduleCreateUseCase {
+    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final ScheduleDtoMapper mapper;
+    private final ClubRepository clubRepository;
+
+    @Override
+    public Schedule create(ScheduleCreateRequest request) {
+        Instant now = Instant.now();
+
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
+
+        Schedule schedule = mapper.toEntity(request, club, now);
+        return scheduleQueryRepository.save(schedule);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
@@ -3,6 +3,7 @@ package com.example.dgu_semi_erp_back.service.schedule;
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.exception.ScheduleNotFoundException;
 import com.example.dgu_semi_erp_back.mapper.ScheduleDtoMapper;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
@@ -18,8 +19,8 @@ import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
-public class ScheduleCommandService implements ScheduleCreateUseCase {
+
+public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUpdateUseCase {
     private final ScheduleQueryRepository scheduleQueryRepository;
     private final ScheduleDtoMapper mapper;
     private final ClubRepository clubRepository;
@@ -33,5 +34,24 @@ public class ScheduleCommandService implements ScheduleCreateUseCase {
 
         Schedule schedule = mapper.toEntity(request, club, now);
         return scheduleQueryRepository.save(schedule);
+    }
+
+    @Transactional
+    @Override
+    public Schedule update(Long id, ScheduleUpdateRequest request) {
+        Schedule schedule = scheduleQueryRepository.findById(id)
+                .orElseThrow(() -> new ScheduleNotFoundException("해당 일정이 존재하지 않습니다."));
+
+        Schedule updatedSchedule = Schedule.builder()
+                .id(schedule.getId())
+                .club(schedule.getClub())
+                .createdAt(schedule.getCreatedAt())
+                .title(request.title())
+                .date(request.date())
+                .place(request.place())
+                .repeat(request.repeat())
+                .build();
+
+        return scheduleQueryRepository.save(updatedSchedule);
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
@@ -6,8 +6,9 @@ import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.ScheduleNotFoundException;
 import com.example.dgu_semi_erp_back.mapper.ScheduleDtoMapper;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
-import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
+import com.example.dgu_semi_erp_back.repository.schedule.ScheduleCommandRepository;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleCreateUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleDeleteUseCase;
 import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
 import lombok.Locked;
@@ -20,8 +21,8 @@ import java.time.Instant;
 @Service
 @RequiredArgsConstructor
 
-public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUpdateUseCase {
-    private final ScheduleQueryRepository scheduleQueryRepository;
+public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUpdateUseCase, ScheduleDeleteUseCase {
+    private final ScheduleCommandRepository scheduleCommandRepository;
     private final ScheduleDtoMapper mapper;
     private final ClubRepository clubRepository;
 
@@ -33,13 +34,13 @@ public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUp
                 .orElseThrow(() -> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
 
         Schedule schedule = mapper.toEntity(request, club, now);
-        return scheduleQueryRepository.save(schedule);
+        return scheduleCommandRepository.save(schedule);
     }
 
     @Transactional
     @Override
     public Schedule update(Long id, ScheduleUpdateRequest request) {
-        Schedule schedule = scheduleQueryRepository.findById(id)
+        Schedule schedule = scheduleCommandRepository.findById(id)
                 .orElseThrow(() -> new ScheduleNotFoundException("해당 일정이 존재하지 않습니다."));
 
         Schedule updatedSchedule = Schedule.builder()
@@ -52,6 +53,17 @@ public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUp
                 .repeat(request.repeat())
                 .build();
 
-        return scheduleQueryRepository.save(updatedSchedule);
+        return scheduleCommandRepository.save(updatedSchedule);
     }
+
+    @Transactional
+    @Override
+    public void delete(Long id) {
+        Schedule schedule = scheduleCommandRepository.findById(id)
+                .orElseThrow(() -> new ScheduleNotFoundException("해당 일정이 존재하지 않습니다."));
+
+        scheduleCommandRepository.delete(schedule);
+    }
+
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleCommandService.java
@@ -13,10 +13,12 @@ import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleUpdateUseCase;
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.*;
 import lombok.Locked;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -43,17 +45,9 @@ public class ScheduleCommandService implements ScheduleCreateUseCase, ScheduleUp
         Schedule schedule = scheduleCommandRepository.findById(id)
                 .orElseThrow(() -> new ScheduleNotFoundException("해당 일정이 존재하지 않습니다."));
 
-        Schedule updatedSchedule = Schedule.builder()
-                .id(schedule.getId())
-                .club(schedule.getClub())
-                .createdAt(schedule.getCreatedAt())
-                .title(request.title())
-                .date(request.date())
-                .place(request.place())
-                .repeat(request.repeat())
-                .build();
+        schedule.update(request.title(), request.date(), request.place(), request.repeat());
 
-        return scheduleCommandRepository.save(updatedSchedule);
+        return schedule;
     }
 
     @Transactional

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleQueryService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleQueryService.java
@@ -1,0 +1,4 @@
+package com.example.dgu_semi_erp_back.service.schedule;
+
+public class ScheduleQueryService {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleQueryService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/schedule/ScheduleQueryService.java
@@ -1,4 +1,42 @@
 package com.example.dgu_semi_erp_back.service.schedule;
 
-public class ScheduleQueryService {
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleQueryDto.*;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import com.example.dgu_semi_erp_back.mapper.ScheduleDtoMapper;
+import com.example.dgu_semi_erp_back.repository.schedule.ScheduleQueryRepository;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByClubIdUseCase;
+import com.example.dgu_semi_erp_back.usecase.schedule.ScheduleFindByMonthUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+
+public class ScheduleQueryService implements ScheduleFindByClubIdUseCase, ScheduleFindByMonthUseCase {
+    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final ScheduleDtoMapper mapper;
+
+    @Override
+    public List<ScheduleDetail> findByClubId(Long clubId) {
+        List<Schedule> schedules = scheduleQueryRepository.findByClubId(clubId);
+
+        return mapper.toScheduleDetailList(schedules);
+    }
+
+    @Override
+    public List<ScheduleDetail> findByMonth(Long clubId, int year, int month) {
+        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime end = start.plusMonths(1);
+
+        List<Schedule> schedules = scheduleQueryRepository.findByClubIdAndDateBetween(clubId, start, end);
+
+
+        return mapper.toScheduleDetailList(schedules.stream().toList());
+
+    }
+
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleCreateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleCreateUseCase.java
@@ -1,0 +1,9 @@
+package com.example.dgu_semi_erp_back.usecase.schedule;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.ScheduleCreateRequest;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+
+
+public interface ScheduleCreateUseCase {
+    Schedule create(ScheduleCreateRequest request);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleDeleteUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleDeleteUseCase.java
@@ -1,0 +1,6 @@
+package com.example.dgu_semi_erp_back.usecase.schedule;
+
+
+public interface ScheduleDeleteUseCase {
+    void delete(Long id);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleFindByClubIdUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleFindByClubIdUseCase.java
@@ -1,0 +1,9 @@
+package com.example.dgu_semi_erp_back.usecase.schedule;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleQueryDto.ScheduleDetail;
+
+import java.util.List;
+
+public interface ScheduleFindByClubIdUseCase {
+    List<ScheduleDetail> findByClubId(Long clubId);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleFindByMonthUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleFindByMonthUseCase.java
@@ -1,0 +1,9 @@
+package com.example.dgu_semi_erp_back.usecase.schedule;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleQueryDto.ScheduleDetail;
+
+import java.util.List;
+
+public interface ScheduleFindByMonthUseCase {
+    List<ScheduleDetail> findByMonth(Long clubId, int year, int month);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
@@ -2,6 +2,9 @@ package com.example.dgu_semi_erp_back.usecase.schedule;
 
 import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.ScheduleUpdateRequest;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
 
 public interface ScheduleUpdateUseCase {
     Schedule update(Long id, ScheduleUpdateRequest request);

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
@@ -1,0 +1,8 @@
+package com.example.dgu_semi_erp_back.usecase.schedule;
+
+import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.ScheduleUpdateRequest;
+import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
+
+public interface ScheduleUpdateUseCase {
+    Schedule update(ScheduleUpdateRequest request);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/schedule/ScheduleUpdateUseCase.java
@@ -4,5 +4,5 @@ import com.example.dgu_semi_erp_back.dto.schedule.ScheduleCommandDto.ScheduleUpd
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 
 public interface ScheduleUpdateUseCase {
-    Schedule update(ScheduleUpdateRequest request);
+    Schedule update(Long id, ScheduleUpdateRequest request);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
Closes #23  

## 🔎 작업 내용
-ScheduleApi
|METHOD|END POINT|설명|요청|응답|
|---|-----|---|-----|-----|
|POST|/schedule|일정 추가|{ club_id, title, date, place, repeat }|"일정이 추가되었습니다."|
|PUT|/schedule/{id}|일정 편집|{ title, date, place, repeat }|"일정이 수정되었습니다."|
|DELETE|/schedule/{id}|일정 삭제|-|NO_CONTENT|
|GET|/schedule/{club_id}|동아리 일정 전체 조회|-|`List<ScheduleDetail>`|
|GET|/schedule?{club_id}&{year}&{month}|동아리 일정 월별 조회|-|`List<ScheduleDetail>`|

API 문서: https://documenter.getpostman.com/view/39135908/2sB2cd5e9m
- DTO
    - ScheduleCommandDto
        - ScheduleCreateRequest
        - ScheduleCreateResponse (응답 메세지로 대체, 필요시 사용)
        - ScheduleUpdateRequest
        - ScheduleUpdateResponse (응답 메세지로 대체, 필요시 사용)
        
     - ScheduleQueryDto
        - ScheduleDetail / 조회용 DTO
        - ScheduleListResponse / 조회용 DTO 리스트 `List<ScheduleDetail>`

- Service
    - ScheduleCommandService
        - create
        - update
        - delete
        
     - ScheduleQueryService
        - FindByClubId
        - FindByMonth

## 🔎 참고사항
com.example.dgu_semi_erp_back.common.config.DummyDataConfig
본 PR에 Club 1개, Schedule 3개로 구성된 더미데이터가 포함되어 있습니다
더 추가하셔서 사용하시거나, 문제 발생시 위 경로 클래스 삭제 부탁드립니당