### PR TITLE
feat: 동아리별 통장(계좌) 소프트딜리트 API 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
@@ -14,6 +14,7 @@ import com.example.dgu_semi_erp_back.usecase.account.AccountUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -122,4 +123,23 @@ public class AccountApi {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
+
+    /**
+     * 동아리 별 통장 소프트 삭제
+     * @param accountId 통장 ID
+     * @return ResponseStatus, message
+     */
+    @DeleteMapping("/{accountId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<String> deleteAccount(
+            @PathVariable("accountId") Long accountId
+    ) {
+        try {
+            accountUseCase.deleteAccount(accountId);
+            return ResponseEntity.ok("통장이 정상적으로 삭제되었습니다.");
+        } catch (AccountNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/account/Account.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/account/Account.java
@@ -47,4 +47,9 @@ public class Account {
 
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AccountHistory> accountHistories = new ArrayList<>();
+
+    // soft delete
+    public void markAsDeleted(Instant deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/club/Role.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/club/Role.java
@@ -1,8 +1,22 @@
 package com.example.dgu_semi_erp_back.entity.club;
 
+/**
+ * 동아리 내 역할
+ * - priority 기반으로 권한 판별하므로, priority 순서 수정 금지
+ */
 public enum Role {
-    LEADER,        // 동아리 회장
-    VICE_LEADER,   // 부회장
-    TREASURER,     // 총무
-    MEMBER,        // 일반 회원
+    MEMBER(1),        // 일반 회원
+    TREASURER(2),     // 총무
+    VICE_LEADER(3),   // 부회장
+    LEADER(4);        // 동아리 회장
+
+    private final int priority; // 권한 우선순위
+
+    Role(int priority) {
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -125,8 +125,7 @@ public class AccountCommandService implements AccountUseCase {
                 .orElseThrow(() -> new UserNotFoundException("해당 사용자가 존재하지 않습니다."));
 
         // 비회원(동아리 미가입자) 확인
-        if (currentUser == null || currentUser.getClubMembers() == null) {
-            throw new UserNotFoundException("비회원은 통장을 삭제할 수 없습니다.");
+        if (currentUser.getClubMembers() == null || currentUser.getClubMembers().isEmpty()) {
         }
 
         // 요청자의 소속 동아리에 속한 통장인지 확인

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -6,6 +6,8 @@ import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
 import com.example.dgu_semi_erp_back.entity.account.QAccount;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
+import com.example.dgu_semi_erp_back.entity.club.Role;
 import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
@@ -14,6 +16,7 @@ import com.example.dgu_semi_erp_back.repository.account.AccountCommandRepository
 import com.example.dgu_semi_erp_back.repository.account.AccountHistoryQueryRepository;
 import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
+import com.example.dgu_semi_erp_back.repository.club.ClubMemberRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.usecase.account.AccountUseCase;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdateRequest;
@@ -40,6 +43,7 @@ public class AccountCommandService implements AccountUseCase {
     private final ClubRepository clubRepository;
     private final EntityManager entityManager;
     private final AccountDtoMapper mapper;
+    private final ClubMemberRepository clubMemberRepository;
 
     @Override
     public Account create(AccountCreateRequest request) {
@@ -99,5 +103,49 @@ public class AccountCommandService implements AccountUseCase {
 
         return accountQueryRepository.findById(accountId)
                 .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
+    }
+
+    /**
+     * 통장 삭제
+     * - 비회원(동아리 미가입자)는 삭제 불가
+     * - 삭제 요청자의 소속 동아리에 속한 통장이어야만 삭제 가능
+     * - 동아리 내에서 관리자 또는 회계 등 높은 권한을 가진 사용자만 삭제 가능
+     * @param accountId 통장 ID
+     */
+    @Transactional
+    @Override
+    public void deleteAccount(Long accountId) {
+        Account account = accountQueryRepository.findById(accountId)
+                .orElseThrow(() -> new AccountNotFoundException("해당 통장이 존재하지 않습니다."));
+
+        // 요청자 정보 반환 -> 추가 필요
+        // User currentUser = getCurrentUser();
+        // 현재는 임시 구현
+        User currentUser = userRepository.findById(1L)
+                .orElseThrow(() -> new UserNotFoundException("해당 사용자가 존재하지 않습니다."));
+
+        // 비회원(동아리 미가입자) 확인
+        if (currentUser == null || currentUser.getClubMembers() == null) {
+            throw new UserNotFoundException("비회원은 통장을 삭제할 수 없습니다.");
+        }
+
+        // 요청자의 소속 동아리에 속한 통장인지 확인
+        long clubMemberId = currentUser.getClubMembers().stream()
+                .filter(clubMember -> clubMember.getClub().getId().equals(account.getClub().getId()))
+                .map(ClubMember::getId)
+                .findFirst()
+                .orElseThrow(() -> new UserNotFoundException("해당 동아리의 통장이 아닙니다."));
+
+        // 요청자 권한 확인 - 해당 clubMemberId를 가진 ClubMember의 Role이 MEMBER보다 높은지 확인
+        ClubMember clubMember = clubMemberRepository.findById(clubMemberId)
+                .orElseThrow(() -> new UserNotFoundException("해당 동아리의 통장이 아닙니다."));
+
+        if (clubMember.getRole().getPriority() <= Role.MEMBER.getPriority()) {
+            throw new UserNotFoundException("권한이 부족합니다.");
+        }
+
+        // soft delete
+        account.markAsDeleted(Instant.now());
+        accountCommandRepository.save(account);
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
@@ -18,4 +18,5 @@ public interface AccountUseCase {
             Long accountId,
             AccountUpdateRequest request
     );
+    void deleteAccount(Long accountId);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
#31 

## 🔎 작업 내용
- DELETE `/account/{accountId}` API 엔드포인트 구현
   - `deletedAt` 타임스탬프 설정으로 소프트 삭제
<img width="1136" alt="스크린샷 2025-04-26 15 27 36" src="https://github.com/user-attachments/assets/dcc5d46c-1624-438d-9acf-bddbc3c51c37" />

- 동아리 내 권한 체크 기능 구현
- `Role` ENUM 우선순위 기반 권한을 포함하도록 업데이트 (`priority` 필드를 포함)
- 비회원 및 권한 없는 사용자의 삭제 요청 시 예외 처리
   - 사용자는 `MEMBER`보다 높은 우선순위 역할을 가져야 삭제 요청 가능
- AccountHistory(거래기록)는 삭제하지 않고 영구 보관

### 정상 응답
<img width="479" alt="스크린샷 2025-04-26 15 40 41" src="https://github.com/user-attachments/assets/e1c0e1f1-ebf7-4f8e-8317-bf29e210a76b" />

### 권한 부족 (500 ERROR)
<img width="483" alt="스크린샷 2025-04-26 15 41 20" src="https://github.com/user-attachments/assets/27b7cf44-1090-481b-a5a8-1a2d0ce01b37" />



## 🔎 참고사항
- 인증(로그인) 검증 로직 추가 필요
- [POSTMAN API 문서 업데이트](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt)