### PR TITLE
update : 유저 정보 조회 API 개선

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
@@ -18,7 +18,7 @@ public final class UserClubMemberDto {
     @Builder
     public record ClubRegisterRequest(Long clubId,String role,String status) {}
     @Builder
-    public record ClubRegisterResponse (String message, ClubSummery club){}
+    public record ClubRegisterResponse (String message, Club club){}
     @Builder
     public record ClubMemberDetail(
             String name,

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/user/UserCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/user/UserCommandDto.java
@@ -21,6 +21,7 @@ public final class UserCommandDto{
 
     @Builder
     public record UserRoleUpdateRequest(
+            @NotNull Long clubId,
             @NotNull Role role
     ){}
     @Builder
@@ -33,7 +34,6 @@ public final class UserCommandDto{
             Long id,
             String name,
             String email,
-            Role role,
             List<ClubProjection.ClubSummery> club
     ) {}
     @Builder

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/auth/user/User.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/auth/user/User.java
@@ -17,7 +17,6 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Setter
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,10 +41,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Integer studentNumber;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role;
-
     @ColumnDefault("false")
     @Column(columnDefinition = "TINYINT(1)")
     private boolean isVerified; // 이메일 인증 여부
@@ -55,4 +50,8 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ClubMember> clubMembers;
+
+    public void changeEmail(String newEmail) {
+        this.email = newEmail;
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/ClubMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/ClubMapper.java
@@ -2,6 +2,7 @@ package com.example.dgu_semi_erp_back.mapper;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
 import org.mapstruct.*;
 
 import java.time.Instant;
@@ -13,11 +14,5 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
 )
 public interface ClubMapper {
-    @Mapping(target = "id", ignore = true)
-    @Mapping(source = "role", target = "role")
-    void updateUserRole(@MappingTarget User user, UserRoleUpdateRequest request);
 
-    @Mapping(target = "id", ignore = true)
-    @Mapping(source = "email", target = "email")
-    void updateUserEmail(@MappingTarget User user, UserEmailUpdateRequest request);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/UserClubMemberMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/UserClubMemberMapper.java
@@ -2,6 +2,7 @@ package com.example.dgu_semi_erp_back.mapper;
 
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubRegisterRequest;
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.entity.club.ClubMember;
@@ -22,14 +23,14 @@ public interface UserClubMemberMapper {
     @Mapping(source = "registeredAt", target = "joinedAt")
     ClubMemberDetail toDto(ClubMember clubMember);
 
-    @Mapping(target = "role", defaultValue = "MEMBER")
-    @Mapping(target = "status", defaultValue = "HOLD")
-    @Mapping(target = "club", ignore = true)
-    @Mapping(target = "user", ignore = true)
-    ClubMember toEntity(ClubRegisterRequest ClubRegisterRequestDto,Long clubId,Long userId, LocalDateTime registeredAt);
-    @AfterMapping
-    default void assignEntities(@MappingTarget ClubMember member, Long clubId, Long userId) {
-        member.setClub(Club.builder().id(clubId).build());
-        member.setUser(User.builder().id(userId).build());
-    }
+    @Mapping(source = "ClubRegisterRequestDto.status", target = "status", defaultValue = "HOLD")
+    @Mapping(target = "id",ignore = true)
+    ClubMember toEntity(ClubRegisterRequest ClubRegisterRequestDto,Club club,User user, LocalDateTime registeredAt);
+
+    ClubMember toEntity(@MappingTarget ClubMember clubMember,UserRoleUpdateRequest request);
+
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(source = "role", target = "role")
+    void updateUserRole(@MappingTarget ClubMember clubMember, UserRoleUpdateRequest request);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/UserMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/UserMapper.java
@@ -13,11 +13,8 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
 )
 public interface UserMapper {
-    @Mapping(target = "id", ignore = true)
-    @Mapping(source = "role", target = "role")
-    void updateUserRole(@MappingTarget User user, UserRoleUpdateRequest request);
-
-    @Mapping(target = "id", ignore = true)
-    @Mapping(source = "email", target = "email")
-    void updateUserEmail(@MappingTarget User user, UserEmailUpdateRequest request);
+    default User toEntity(@MappingTarget User user, UserEmailUpdateRequest request) {
+        user.changeEmail(request.email());
+        return user;
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
@@ -1,0 +1,20 @@
+package com.example.dgu_semi_erp_back.projection.club;
+
+import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.*;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
+import com.querydsl.core.annotations.QueryProjection;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
+
+public class ClubMemberProjection {
+    public record ClubMemberSummery(
+            Long id,
+            Role role,
+            MemberStatus status,
+            LocalDateTime registeredAt
+    ) {}
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
@@ -1,5 +1,6 @@
 package com.example.dgu_semi_erp_back.projection.club;
 
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
 import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.entity.club.Role;
@@ -13,6 +14,7 @@ public class ClubProjection {
             Long id,
             String name,
             String affiliation,
-            ClubStatus status
+            ClubStatus status,
+            ClubMemberProjection.ClubMemberSummery clubMembers
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubMemberRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubMemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     Boolean existsClubMemberByUserIdAndClubId(Long userId, Long clubId);
     List<ClubMember> findClubIdsByUserId(Long userId);
+    Optional<ClubMember> findClubMemberByUserIdAndClubId(Long userId, Long clubId);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
@@ -1,11 +1,11 @@
 package com.example.dgu_semi_erp_back.repository.club;
 import com.example.dgu_semi_erp_back.entity.club.Club;
-import com.example.dgu_semi_erp_back.projection.club.ClubProjection;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.*;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
     Optional<Club> findClubIdById(Long id);
-    Optional<ClubProjection.ClubSummery> findClubById(Long id);
+    Optional<ClubSummery> findClubById(Long id);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/auth/AuthService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/auth/AuthService.java
@@ -113,7 +113,7 @@ public class AuthService {
                 .password(BCrypt.hashpw(signUpRequest.password(), BCrypt.gensalt()))
                 .email(signUpRequest.email())
                 .nickname(signUpRequest.nickname())
-                .role(Role.MEMBER)
+//                .role(Role.MEMBER)
                 .isVerified(true)
                 .build();
 

--- a/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
@@ -5,20 +5,21 @@ import com.example.dgu_semi_erp_back.common.exception.ErrorCode;
 import com.example.dgu_semi_erp_back.common.jwt.JwtUtil;
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.*;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
-import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
-import com.example.dgu_semi_erp_back.entity.club.ClubMember;
-import com.example.dgu_semi_erp_back.entity.club.Role;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
 import com.example.dgu_semi_erp_back.mapper.UserClubMemberMapper;
 import com.example.dgu_semi_erp_back.mapper.UserMapper;
+import com.example.dgu_semi_erp_back.projection.club.ClubMemberProjection;
 import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
 import com.example.dgu_semi_erp_back.repository.club.ClubMemberRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.usecase.club.ClubMemberCreateUseCase;
 import com.example.dgu_semi_erp_back.usecase.user.UserUpdateUseCase;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class UserService implements UserUpdateUseCase, ClubMemberCreateUseCase {
     private final UserMapper userMapper;
     private final UserClubMemberMapper userClubMemberMapper;
     private final JwtUtil jwtutil;
+    private final JPAQueryFactory queryFactory;
     public User findUserByAccessToken(String accessToken) throws UserNotFoundException{
         String userName = jwtutil.getUsernameFromToken(accessToken);
         User user = userRepository.findByUsername(userName)
@@ -49,11 +53,35 @@ public class UserService implements UserUpdateUseCase, ClubMemberCreateUseCase {
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다.1"));
         System.out.println(user.getId());
         List<ClubMember> clubMember = clubMemberRepository.findClubIdsByUserId(user.getId());
+        QClub qClub = QClub.club;
+        QClubMember qMember = QClubMember.clubMember;
+
 
         List<ClubSummery> clubs = new ArrayList<>();
         for(int i=0;i<clubMember.size();i++){
             Long clubId = clubMember.get(i).getClub().getId();
-            ClubSummery club = clubRepository.findClubById(clubId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 동아리입니다."));
+            ClubSummery club = queryFactory
+                    .select(Projections.constructor(
+                            ClubSummery.class,
+                            qClub.id,
+                            qClub.name,
+                            qClub.affiliation,
+                            qClub.status,
+                            Projections.constructor(
+                                    ClubMemberProjection.ClubMemberSummery.class,
+                                    qMember.id,
+                                    qMember.role,
+                                    qMember.status,
+                                    qMember.registeredAt
+                            )
+                    ))
+                    .from(qClub)
+                    .where(qClub.id.eq(clubId))
+                    .join(qMember).on(qMember.club.id.eq(qClub.id))
+                    .fetchOne();
+            if (club == null) {
+                throw new UserNotFoundException("존재하지 않는 동아리입니다.");
+            }
             clubs.add(club);
         }
 
@@ -61,7 +89,6 @@ public class UserService implements UserUpdateUseCase, ClubMemberCreateUseCase {
         return UserResponse.builder()
                 .id(user.getId())
                 .name(user.getUsername())
-                .role(user.getRole())
                 .email(user.getEmail())
                 .club(clubs)
                 .build();
@@ -71,12 +98,14 @@ public class UserService implements UserUpdateUseCase, ClubMemberCreateUseCase {
     @Override
     public User updateRole(Long id, UserRoleUpdateRequest request,String accessToken,String refreshToken) throws UserNotFoundException,CustomException {
         User user = findUserByAccessToken(accessToken);
-        Role userRole = user.getRole();
-        if(userRole==Role.LEADER||userRole==Role.VICE_LEADER){
+        Club club = clubRepository.findClubIdById(request.clubId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 동아리입니다."));
+        Role userRole = clubMemberRepository.findClubMemberByUserIdAndClubId(user.getId(),request.clubId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다.")).getRole();
+        if(userRole==Role.LEADER||userRole==Role.VICE_LEADER|| Objects.equals(user.getId(), id)){
             User target_user = userRepository.findUserById(id)
                     .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-            userMapper.updateUserRole(target_user, request);
-            return target_user;
+            ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(target_user.getId(),club.getId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+            ClubMember newClubMember = userClubMemberMapper.toEntity(clubMember,request);
+            return clubMemberRepository.save(newClubMember).getUser();
         }
         else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
@@ -87,28 +116,35 @@ public class UserService implements UserUpdateUseCase, ClubMemberCreateUseCase {
     public User updateEmail(Long id,UserEmailUpdateRequest request,String accessToken,String refreshToken) throws UserNotFoundException,CustomException {
         try{
             User user = findUserByAccessToken(accessToken);
+            ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(id,user.getId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));;
+
             User target_user = userRepository.findUserById(id)
                     .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-            userMapper.updateUserEmail(target_user, request);
-            return target_user;
+            if(Objects.equals(user.getId(), target_user.getId())||clubMember.getRole()==Role.LEADER||clubMember.getRole()==Role.VICE_LEADER){
+                User newUser = userMapper.toEntity(target_user, request);
+                return userRepository.save(newUser);
+            }
+            else{
+                throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+            }
+
         }
         catch(Exception e){
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
-
     }
     @Transactional
     @Override
     public ClubRegisterResponse createClubMember(ClubRegisterRequest clubRegisterRequest,String accessToken,String refreshToken) throws ClubNotFoundException,UserNotFoundException {
         User user = findUserByAccessToken(accessToken);
-        ClubSummery club = clubRepository.findClubById(clubRegisterRequest.clubId()).orElseThrow(() -> new ClubNotFoundException("존재하지 않는 동아리입니다."));
-        if(clubMemberRepository.existsClubMemberByUserIdAndClubId(user.getId(), club.id())){
+        Club club = clubRepository.findClubIdById(clubRegisterRequest.clubId()).orElseThrow(() -> new ClubNotFoundException("존재하지 않는 동아리입니다."));
+        if(clubMemberRepository.existsClubMemberByUserIdAndClubId(user.getId(), club.getId())){
             throw new CustomException(ErrorCode.DUPLICATED_MEMBER);
         }
 
 
         LocalDateTime now = LocalDateTime.now();
-        ClubMember clubMember = userClubMemberMapper.toEntity(clubRegisterRequest,club.id(),user.getId(),now);
+        ClubMember clubMember = userClubMemberMapper.toEntity(clubRegisterRequest,club,user,now);
         clubMemberRepository.save(clubMember);
         return ClubRegisterResponse.builder().message("가입 신청 성공").club(club).build();
     }


### PR DESCRIPTION
## 🔎 관련 이슈
#30 

## 🔎 작업 내용

- 유저 정보 조회 API 동아리명, 직위, 활성화여부 추가
- User 엔티티에서 Role 컬럼 제거, Setter 제거
- UserClubMemberMapper PostMapping이 아닌 직접 엔티티 저장 방식으로 변경


## 🔎 참고사항
- API 문서 : https://documenter.getpostman.com/view/33657317/2sB2cUAiAt#f275ba44-516a-4890-94b2-0dd8e9de8c85
