### PR TITLE
fix : account sse 알림 서비스 추가

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/controller/NotificationController.java
@@ -10,6 +10,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Map;
+
+@CrossOrigin(origins = "*")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notifications")
@@ -35,4 +38,11 @@ public class NotificationController {
         return notificationService.getCategoryCounts(userId);
     }
 
+
+        /* sse 알림 테스트
+@PostMapping("/send-test")
+public void sendTestNotification(@RequestParam Long userId, @RequestBody Map<String, Object> payload) {
+    sseEmitterService.sendNotification(userId, payload);
+}
+*/
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationCommandRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/notification/NotificationCommandRepository.java
@@ -1,0 +1,7 @@
+package com.example.dgu_semi_erp_back.repository.notification;
+
+import com.example.dgu_semi_erp_back.entity.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationCommandRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/notification/NotificationService.java
@@ -1,14 +1,20 @@
 package com.example.dgu_semi_erp_back.service.notification;
 
 import com.example.dgu_semi_erp_back.dto.notification.NotificationQueryDto.NotificationResponse;
+import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.notification.Category;
+import com.example.dgu_semi_erp_back.entity.notification.Notification;
 import com.example.dgu_semi_erp_back.mapper.NotificationMapper;
+import com.example.dgu_semi_erp_back.repository.notification.NotificationCommandRepository;
 import com.example.dgu_semi_erp_back.repository.notification.NotificationQueryRepository;
 import com.example.dgu_semi_erp_back.dto.notification.NotificationCountDto.NotificationCategoryCountResponse;
+import com.example.dgu_semi_erp_back.service.notification.SseEmitterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Service
@@ -17,6 +23,8 @@ public class NotificationService {
 
     private final NotificationQueryRepository notificationQueryRepository;
     private final NotificationMapper mapper;
+    private final NotificationCommandRepository notificationCommandRepository;
+    private final SseEmitterService sseEmitterService;
 
     public Page<NotificationResponse> getNotifications(String categoryName, Long userId, Pageable pageable) {
         Category category = null;
@@ -37,5 +45,18 @@ public class NotificationService {
         return NotificationCategoryCountResponse.builder()
                 .categoryCounts(counts)
                 .build();
+    }
+
+    public void send(User user, Category category, String title, String content) {
+        Notification notification = Notification.builder()
+                .user(user)
+                .category(category)
+                .title(title)
+                .content(content)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Notification savedNotification = notificationCommandRepository.save(notification);
+        sseEmitterService.sendNotification(user.getId(), savedNotification);
     }
 }


### PR DESCRIPTION
## 🔎 관련 이슈
    통장 개설/수정/삭제 시 SSE 알림 전송

## 🔎 작업 내용
   	•	AccountApi에 통장 개설 / 수정 / 삭제 시 알림 전송 로직 추가
	•	NotificationService.send() 호출을 통해 SSE 기반 알림 전송
	•	알림 카테고리는 BANKBOOK, 수신자는 통장 소유자

•	개설: “통장이 개설되었습니다. 계좌번호: 123-456”
	•	수정: “통장 정보가 수정되었습니다. 계좌번호: 123-456”
	•	삭제: “통장이 삭제되었습니다. 계좌번호: 123-456”


## 🔎 참고사항
create는 postman 테스트했고 나머지는 테스트하고 바로 수정할게요 pr