### PR TITLE
feat: BudgetPlan CRUD 및 필터링&페이징 API 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/budget/BudgetPlanApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/budget/BudgetPlanApi.java
@@ -4,35 +4,47 @@ import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanC
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanCreateResponse;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanUpdateResponse;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanUpdateRequest;
-import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanDetail;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetCreatePlanUseCase;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetFindByIdUseCase;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetUpdatePlanUseCase;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto.BudgetPlanSearchResponse.BudgetPlanSummaryResponse;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto.BudgetPlanDetailResponse;
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.mapper.BudgetDtoMapper;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
+import com.example.dgu_semi_erp_back.usecase.budget.CreateBudgetPlanUseCase;
+import com.example.dgu_semi_erp_back.usecase.budget.FindFilteredBudgetPlansUseCase;
+import com.example.dgu_semi_erp_back.usecase.budget.FindBudgetPlanUseCase;
+import com.example.dgu_semi_erp_back.usecase.budget.UpdateBudgetPlanUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/budget/plan")
 @Validated
 public class BudgetPlanApi {
-    private final BudgetCreatePlanUseCase budgetCreatePlanUseCase;
-    private final BudgetUpdatePlanUseCase budgetUpdatePlanUseCase;
-    private final BudgetFindByIdUseCase budgetFindByIdUseCase;
+    private final CreateBudgetPlanUseCase createBudgetPlanUseCase;
+    private final UpdateBudgetPlanUseCase updateBudgetPlanUseCase;
+    private final FindBudgetPlanUseCase findBudgetPlanUseCase;
+    private final FindFilteredBudgetPlansUseCase findFilteredBudgetPlansUseCase;
+    private final BudgetDtoMapper budgetDtoMapper;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public BudgetPlanCreateResponse create(
             @RequestBody @Valid BudgetPlanCreateRequest request
     ) {
-        var budgetPlan = budgetCreatePlanUseCase.create(request);
+        var budgetPlan = createBudgetPlanUseCase.create(request);
 
-        return BudgetPlanCreateResponse.builder()
-                .budgetPlan(budgetPlan)
-                .build();
+        return budgetDtoMapper.toCreateResponse(budgetPlan);
     }
 
     @PutMapping("/{id}")
@@ -41,16 +53,51 @@ public class BudgetPlanApi {
             @PathVariable Long id,
             @RequestBody @Valid BudgetPlanUpdateRequest request
     ) {
-        var updatedPlan = budgetUpdatePlanUseCase.update(id, request);
+        var updatedPlan = updateBudgetPlanUseCase.update(id, request);
 
-        return BudgetPlanUpdateResponse.builder()
-                .budgetPlan(updatedPlan)
-                .build();
+        return budgetDtoMapper.toUpdateResponse(updatedPlan);
     }
 
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public BudgetPlanDetail findById(@PathVariable Long id) {
-        return budgetFindByIdUseCase.findBudgetPlanById(id);
+    public BudgetPlanDetailResponse getBudgetPlanById(@PathVariable Long id) {
+        return budgetDtoMapper.toDetailResponse(findBudgetPlanUseCase.findBudgetPlanById(id));
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public BudgetPlanQueryDto.BudgetPlanSearchResponse getFilteredBudgetPlans(
+            @PageableDefault(size = 5) Pageable pageable,
+            @RequestParam(required = false) String executeType,
+            @RequestParam(required = false) String clubName,
+            @RequestParam(required = false) String content,
+            @RequestParam(required = false) String author,
+            @RequestParam(required = false) LocalDateTime expectedPaymentDate,
+            @RequestParam(required = false) Integer paymentAmount,
+            @RequestParam(required = false) LocalDateTime createdAt,
+            @RequestParam(required = false) BudgetStatus status
+    ) {
+        var budgetPlanPage = findFilteredBudgetPlansUseCase.findFilteredBudgetPlans(
+                pageable,
+                executeType,
+                clubName,
+                content,
+                author,
+                expectedPaymentDate,
+                paymentAmount,
+                createdAt,
+                status
+        );
+
+        var budgetPlanResponses = budgetDtoMapper.toSummaryResponseList(budgetPlanPage.getContent());
+
+        return BudgetPlanQueryDto.BudgetPlanSearchResponse.builder()
+                .content(budgetPlanResponses)
+                .pageNumber(budgetPlanPage.getNumber())
+                .pageSize(budgetPlanPage.getSize())
+                .totalElements(budgetPlanPage.getTotalElements())
+                .totalPages(budgetPlanPage.getTotalPages())
+                .last(budgetPlanPage.isLast())
+                .build();
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/DummyDataConfig.java
@@ -1,6 +1,7 @@
 package com.example.dgu_semi_erp_back.common.config;
 
 import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
 import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.entity.schedule.Schedule;
 import com.example.dgu_semi_erp_back.entity.schedule.type.ScheduleRepeat;
@@ -30,7 +31,7 @@ public class DummyDataConfig {
             Club club = Club.builder()
                     .name("디벨로퍼")
                     .affiliation("공대")
-                    .status(MemberStatus.ACTIVE)
+                    .status(ClubStatus.ACTIVE)
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build();

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/budget/BudgetPlanCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/budget/BudgetPlanCommandDto.java
@@ -4,6 +4,7 @@ import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
 import com.example.dgu_semi_erp_back.entity.budget.types.PaymentType;
 import lombok.Builder;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -13,10 +14,11 @@ public final class BudgetPlanCommandDto {
     @Builder
     public record BudgetPlanCreateRequest(
             String executeType,
+            String clubName,
             PaymentType paymentType,
-            LocalDateTime paymentDate,
             String content,
             String author,
+            LocalDateTime expectedPaymentDate,
             int paymentAmount,
             String planReviewer,
             String planApprover
@@ -24,25 +26,51 @@ public final class BudgetPlanCommandDto {
 
     @Builder
     public record BudgetPlanCreateResponse(
-            BudgetPlan budgetPlan
+            Long id,
+            String executeType,
+            String clubName,
+            PaymentType paymentType,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            int paymentAmount,
+            BudgetStatus status,
+            String planReviewer,
+            String planApprover,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
     ) {}
 
     @Builder
     public record BudgetPlanUpdateRequest(
+            Long id,
             String executeType,
             PaymentType paymentType,
-            LocalDateTime paymentDate,
             String content,
             String author,
+            LocalDateTime expectedPaymentDate,
             int paymentAmount,
             String planReviewer,
             String planApprover,
-            BudgetStatus status
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
     ) {}
 
     @Builder
     public record BudgetPlanUpdateResponse(
-            BudgetPlan budgetPlan
+            Long id,
+            String executeType,
+            String clubName,
+            PaymentType paymentType,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            int paymentAmount,
+            BudgetStatus status,
+            String planReviewer,
+            String planApprover,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
     ) {}
 
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/budget/BudgetPlanQueryDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/budget/BudgetPlanQueryDto.java
@@ -1,5 +1,53 @@
 package com.example.dgu_semi_erp_back.dto.budget;
 
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.entity.budget.types.PaymentType;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public final class BudgetPlanQueryDto {
     private BudgetPlanQueryDto() {}
+
+    @Builder
+    public record BudgetPlanDetailResponse(
+            Long id,
+            String executeType,
+            String clubName,
+            PaymentType paymentType,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            Integer paymentAmount,
+            BudgetStatus status,
+            String planReviewer,
+            String planApprover,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {}
+
+    @Builder
+    public record BudgetPlanSearchResponse(
+            List<BudgetPlanSummaryResponse> content,
+            Integer pageNumber,
+            Integer pageSize,
+            Long totalElements,
+            Integer totalPages,
+            Boolean last
+    ) {
+        @Builder
+        public record BudgetPlanSummaryResponse(
+                Long id,
+                String executeType,
+                String clubName,
+                String content,
+                String author,
+                LocalDateTime expectedPaymentDate,
+                Integer paymentAmount,
+                LocalDateTime createdAt,
+                BudgetStatus status
+        ) {}
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/budget/BudgetPlan.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/budget/BudgetPlan.java
@@ -3,6 +3,8 @@ package com.example.dgu_semi_erp_back.entity.budget;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanUpdateRequest;
 import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
 import com.example.dgu_semi_erp_back.entity.budget.types.PaymentType;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -10,7 +12,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -24,12 +26,14 @@ public class BudgetPlan {
     @Column(nullable = false)
     private String executeType; // 집행 유형
 
+    @ManyToOne
+    @JoinColumn(name = "club_id", nullable = true)
+    @JsonIgnore
+    private Club club; // 동아리
+
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private PaymentType paymentType; // 결제 타입
-
-    @Column(nullable = false)
-    private LocalDateTime paymentDate; // 결제일
 
     @Column(nullable = false)
     private String content; // 내용
@@ -38,7 +42,14 @@ public class BudgetPlan {
     private String author; // 기안자
 
     @Column(nullable = false)
+    private LocalDateTime expectedPaymentDate; // 결제 예정일
+
+    @Column(nullable = false)
     private int paymentAmount; // 금액
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private BudgetStatus status; // 상태
 
     @Column(nullable = false)
     private String planReviewer; // 검토자
@@ -47,14 +58,10 @@ public class BudgetPlan {
     private String planApprover; // 승인자
 
     @Column(nullable = false)
-    @Enumerated(value = EnumType.STRING)
-    private BudgetStatus status;
+    private LocalDateTime createdAt; // 기안일
 
     @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private LocalDateTime updatedAt; // 수정날짜
 
     @Builder(
             builderClassName = "UpdateBudgetPlanBuilder",
@@ -64,13 +71,13 @@ public class BudgetPlan {
     public void update(BudgetPlanUpdateRequest request, LocalDateTime updatedAt) {
         this.executeType = request.executeType();
         this.paymentType = request.paymentType();
-        this.paymentDate = request.paymentDate();
         this.content = request.content();
         this.author = request.author();
+        this.expectedPaymentDate = request.expectedPaymentDate();
+        this.status = BudgetStatus.HOLD;
         this.paymentAmount = request.paymentAmount();
         this.planReviewer = request.planReviewer();
         this.planApprover = request.planApprover();
-        this.status = request.status();
         this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/BudgetDtoMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/BudgetDtoMapper.java
@@ -1,20 +1,49 @@
 package com.example.dgu_semi_erp_back.mapper;
 
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanUpdateResponse;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanCreateResponse;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanCreateRequest;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto.BudgetPlanSearchResponse.BudgetPlanSummaryResponse;
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto.BudgetPlanDetailResponse;
 import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanDetail;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
 @Mapper(componentModel = SPRING)
 public interface BudgetDtoMapper {
+    @Mapping(target = "club", source = "club")
+    @Mapping(target = "status", source = "status")
+    @Mapping(target = "createdAt", source = "createdAt")
+    @Mapping(target = "updatedAt", source = "updatedAt")
+    @Mapping(target = "id", ignore = true)
     BudgetPlan toEntity(
             BudgetPlanCreateRequest dto,
+            Club club,
             BudgetStatus status,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     );
+
+    @Mapping(target = "clubName", source = "club.name")
+    BudgetPlanCreateResponse toCreateResponse(BudgetPlan budgetPlan);
+
+    @Mapping(target = "clubName", source = "club.name")
+    BudgetPlanUpdateResponse toUpdateResponse(BudgetPlan budgetPlan);
+
+    @Mapping(target = "clubName", source = "club.name")
+    BudgetPlanDetailResponse toDetailResponse(BudgetPlanDetail budgetPlanDetail);
+
+    @Mapping(target = "clubName", source = "club.name")
+    BudgetPlanSummaryResponse toSummaryResponse(BudgetPlanSummary summary);
+
+    List<BudgetPlanSummaryResponse> toSummaryResponseList(List<BudgetPlanSummary> summaries);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/budget/BudgetPlanProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/budget/BudgetPlanProjection.java
@@ -2,6 +2,7 @@ package com.example.dgu_semi_erp_back.projection.budget;
 
 import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
 import com.example.dgu_semi_erp_back.entity.budget.types.PaymentType;
+import com.example.dgu_semi_erp_back.entity.club.Club;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -11,10 +12,12 @@ public final class BudgetPlanProjection {
     public record BudgetPlanSummary(
             Long id,
             String executeType,
-            LocalDateTime paymentDate,
+            Club club,
             String content,
             String author,
+            LocalDateTime expectedPaymentDate,
             int paymentAmount,
+            LocalDateTime createdAt,
             BudgetStatus status
     ) {}
 
@@ -22,14 +25,15 @@ public final class BudgetPlanProjection {
     public record BudgetPlanDetail(
             Long id,
             String executeType,
+            Club club,
             PaymentType paymentType,
-            LocalDateTime paymentDate,
             String content,
             String author,
+            LocalDateTime expectedPaymentDate,
             int paymentAmount,
+            BudgetStatus status,
             String planReviewer,
             String planApprover,
-            BudgetStatus status,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/budget/BudgetPlanQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/budget/BudgetPlanQueryRepository.java
@@ -3,13 +3,13 @@ package com.example.dgu_semi_erp_back.repository.budget;
 import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
 import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface BudgetPlanQueryRepository extends JpaRepository<BudgetPlan, Long> {
     Optional<BudgetPlanDetail> findBudgetPlanById(Long id);
-
-    List<BudgetPlanSummary> findAllBy();
+    Page<BudgetPlanSummary> findAllBy(Pageable pageable);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/budget/BudgetPlanRepositorySupport.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/budget/BudgetPlanRepositorySupport.java
@@ -1,0 +1,120 @@
+package com.example.dgu_semi_erp_back.repository.budget;
+
+import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
+import com.example.dgu_semi_erp_back.entity.budget.QBudgetPlan;
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public class BudgetPlanRepositorySupport extends QuerydslRepositorySupport {
+    QBudgetPlan budgetPlan = QBudgetPlan.budgetPlan;
+
+    public BudgetPlanRepositorySupport() {
+        super(BudgetPlan.class);
+    }
+
+    public Page<BudgetPlanSummary> findFilteredBudgetPlans(
+            Pageable pageable,
+            String executeType,
+            String clubName,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            Integer paymentAmount,
+            LocalDateTime createdAt,
+            BudgetStatus status
+    ) {
+        BooleanExpression conditions = createFilterConditions(
+                executeType, clubName, content, author,
+                expectedPaymentDate, paymentAmount, createdAt, status
+        );
+
+        var query = getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        BudgetPlanSummary.class,
+                        budgetPlan.id,
+                        budgetPlan.executeType,
+                        budgetPlan.club,
+                        budgetPlan.content,
+                        budgetPlan.author,
+                        budgetPlan.expectedPaymentDate,
+                        budgetPlan.paymentAmount,
+                        budgetPlan.createdAt,
+                        budgetPlan.status
+                ))
+                .from(budgetPlan)
+                .leftJoin(budgetPlan.club)
+                .where(conditions)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        // Sorting 적용
+        pageable.getSort().forEach(order -> {
+            if (order.isAscending()) {
+                query.orderBy(budgetPlan.createdAt.asc());
+            } else {
+                query.orderBy(budgetPlan.createdAt.desc());
+            }
+        });
+
+        var result = query.fetch();
+
+        // Total count 쿼리
+        Long total = getQuerydsl().createQuery()
+                .select(budgetPlan.count())
+                .from(budgetPlan)
+                .where(conditions)
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression createFilterConditions(
+            String executeType,
+            String clubName,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            Integer paymentAmount,
+            LocalDateTime createdAt,
+            BudgetStatus status
+    ) {
+        BooleanExpression conditions = budgetPlan.isNotNull();
+
+        if (executeType != null && !executeType.isEmpty()) {
+            conditions = conditions.and(budgetPlan.executeType.eq(executeType));
+        }
+        if (clubName != null && !clubName.isEmpty()) {
+            conditions = conditions.and(budgetPlan.club.name.like("%" + clubName + "%"));
+        }
+        if (content != null && !content.isEmpty()) {
+            conditions = conditions.and(budgetPlan.content.like("%" + content + "%"));
+        }
+        if (author != null && !author.isEmpty()) {
+            conditions = conditions.and(budgetPlan.author.like("%" + author + "%"));
+        }
+        if (expectedPaymentDate != null) {
+            conditions = conditions.and(budgetPlan.expectedPaymentDate.eq(expectedPaymentDate));
+        }
+        if (paymentAmount != null) {
+            conditions = conditions.and(budgetPlan.paymentAmount.eq(paymentAmount));
+        }
+        if (createdAt != null) {
+            conditions = conditions.and(budgetPlan.createdAt.eq(createdAt));
+        }
+        if (status != null) {
+            conditions = conditions.and(budgetPlan.status.eq(status));
+        }
+
+        return conditions;
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
@@ -8,4 +8,5 @@ import java.util.*;
 public interface ClubRepository extends JpaRepository<Club, Long> {
     Optional<Club> findClubIdById(Long id);
     Optional<ClubSummery> findClubById(Long id);
+    Optional<Club> findByName(String name);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/budget/BudgetPlanCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/budget/BudgetPlanCommandService.java
@@ -6,10 +6,12 @@ import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanC
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanUpdateRequest;
 import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.entity.club.Club;
 import com.example.dgu_semi_erp_back.mapper.BudgetDtoMapper;
 import com.example.dgu_semi_erp_back.repository.budget.BudgetPlanQueryRepository;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetCreatePlanUseCase;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetUpdatePlanUseCase;
+import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
+import com.example.dgu_semi_erp_back.usecase.budget.CreateBudgetPlanUseCase;
+import com.example.dgu_semi_erp_back.usecase.budget.UpdateBudgetPlanUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,15 +20,20 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class BudgetPlanCommandService implements BudgetCreatePlanUseCase, BudgetUpdatePlanUseCase {
+public class BudgetPlanCommandService implements CreateBudgetPlanUseCase, UpdateBudgetPlanUseCase {
     private final BudgetPlanQueryRepository budgetPlanRepository;
+    private final ClubRepository clubRepository;
     private final BudgetDtoMapper mapper;
 
+    @Transactional
     @Override
     public BudgetPlan create(BudgetPlanCreateRequest request) {
         LocalDateTime now = LocalDateTime.now();
 
-        BudgetPlan budgetPlan = mapper.toEntity(request, BudgetStatus.HOLD, now, now);
+        Club club = clubRepository.findByName(request.clubName())
+                .orElseThrow(() -> new IllegalArgumentException("Club not found"));
+
+        BudgetPlan budgetPlan = mapper.toEntity(request, club, BudgetStatus.HOLD, now, now);
 
         return budgetPlanRepository.save(budgetPlan);
     }

--- a/src/main/java/com/example/dgu_semi_erp_back/service/budget/BudgetPlanQueryService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/budget/BudgetPlanQueryService.java
@@ -2,22 +2,56 @@ package com.example.dgu_semi_erp_back.service.budget;
 
 import com.example.dgu_semi_erp_back.common.exception.CustomException;
 import com.example.dgu_semi_erp_back.common.exception.ErrorCode;
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
 import com.example.dgu_semi_erp_back.mapper.BudgetDtoMapper;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
 import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanDetail;
 import com.example.dgu_semi_erp_back.repository.budget.BudgetPlanQueryRepository;
-import com.example.dgu_semi_erp_back.usecase.budget.BudgetFindByIdUseCase;
+import com.example.dgu_semi_erp_back.repository.budget.BudgetPlanRepositorySupport;
+import com.example.dgu_semi_erp_back.usecase.budget.FindFilteredBudgetPlansUseCase;
+import com.example.dgu_semi_erp_back.usecase.budget.FindBudgetPlanUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class BudgetPlanQueryService implements BudgetFindByIdUseCase {
+public class BudgetPlanQueryService implements FindBudgetPlanUseCase, FindFilteredBudgetPlansUseCase {
     private final BudgetPlanQueryRepository budgetPlanRepository;
+    private final BudgetPlanRepositorySupport budgetPlanRepositorySupport;
     private final BudgetDtoMapper mapper;
 
     @Override
     public BudgetPlanDetail findBudgetPlanById(Long id) {
         return budgetPlanRepository.findBudgetPlanById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.BUDGET_PLAN_NOT_FOUND));
+    }
+
+    @Override
+    public Page<BudgetPlanSummary> findFilteredBudgetPlans(
+            Pageable pageable,
+            String executeType,
+            String clubName,
+            String content,
+            String author,
+            LocalDateTime expectedPaymentDate,
+            Integer paymentAmount,
+            LocalDateTime createdAt,
+            BudgetStatus status
+    ) {
+        return budgetPlanRepositorySupport.findFilteredBudgetPlans(
+                pageable,
+                executeType,
+                clubName,
+                content,
+                author,
+                expectedPaymentDate,
+                paymentAmount,
+                createdAt,
+                status
+        );
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/CreateBudgetPlanUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/CreateBudgetPlanUseCase.java
@@ -3,6 +3,6 @@ package com.example.dgu_semi_erp_back.usecase.budget;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto.BudgetPlanCreateRequest;
 import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 
-public interface BudgetCreatePlanUseCase {
+public interface CreateBudgetPlanUseCase {
     BudgetPlan create(BudgetPlanCreateRequest request);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/FindBudgetPlanUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/FindBudgetPlanUseCase.java
@@ -2,8 +2,6 @@ package com.example.dgu_semi_erp_back.usecase.budget;
 
 import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanDetail;
 
-import java.util.Optional;
-
-public interface BudgetFindByIdUseCase {
+public interface FindBudgetPlanUseCase {
     BudgetPlanDetail findBudgetPlanById(Long id);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/FindFilteredBudgetPlansUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/FindFilteredBudgetPlansUseCase.java
@@ -1,0 +1,20 @@
+package com.example.dgu_semi_erp_back.usecase.budget;
+
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
+import com.example.dgu_semi_erp_back.projection.budget.BudgetPlanProjection.BudgetPlanSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+
+public interface FindFilteredBudgetPlansUseCase {
+    Page<BudgetPlanSummary> findFilteredBudgetPlans(Pageable pageable,
+                                                    String executeType,
+                                                    String clubName,
+                                                    String content,
+                                                    String author,
+                                                    LocalDateTime expectedPaymentDate,
+                                                    Integer paymentAmount,
+                                                    LocalDateTime createdAt,
+                                                    BudgetStatus status);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/UpdateBudgetPlanUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/budget/UpdateBudgetPlanUseCase.java
@@ -3,6 +3,6 @@ package com.example.dgu_semi_erp_back.usecase.budget;
 import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanCommandDto;
 import com.example.dgu_semi_erp_back.entity.budget.BudgetPlan;
 
-public interface BudgetUpdatePlanUseCase {
+public interface UpdateBudgetPlanUseCase {
     BudgetPlan update(Long id, BudgetPlanCommandDto.BudgetPlanUpdateRequest request);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
#42

## 🔎 작업 내용
- BudgetPlan 생성(Create) API 구현
- BudgetPlan 수정(Update) API 구현
- BudgetPlan 단건 조회(Read) API 구현
- BudgetPlan 목록 조회(Read, 필터링 및 페이징 지원) API 구현
- BudgetPlan 관련 DTO, UseCase, Mapper 생성 및 연동


## 🔎 참고사항
- 목록 조회 시 executeType, clubName, content, author, expectedPaymentDate, paymentAmount, createdAt, status 등 다양한 필터 조건 지원
- Spring Data JPA의 Pageable을 활용한 페이징 처리 적용
- 향후 예산안 삭제(Delete) 및 승인 기능 추가 예정
