### PR TITLE
update: user API 페이지네이션 필요한 정보만 넘기도록 개선

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/dto/club/ClubDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/club/ClubDto.java
@@ -1,6 +1,6 @@
 package com.example.dgu_semi_erp_back.dto.club;
 
-import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import lombok.Builder;
 
 import java.util.List;
@@ -9,6 +9,6 @@ public final class ClubDto {
     private ClubDto(){}
     @Builder
     public record ClubResponse(
-            List<ClubSummery> clubs
+            List<ClubSummary> clubs
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
@@ -1,7 +1,12 @@
 package com.example.dgu_semi_erp_back.dto.club;
 
+import com.example.dgu_semi_erp_back.dto.budget.BudgetPlanQueryDto;
+import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
+import com.example.dgu_semi_erp_back.entity.budget.types.BudgetStatus;
 import com.example.dgu_semi_erp_back.entity.club.*;
-import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
+import com.example.dgu_semi_erp_back.projection.club.ClubMemberProjection;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -11,6 +16,7 @@ import com.example.dgu_semi_erp_back.entity.club.Role;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public final class UserClubMemberDto {
     private UserClubMemberDto() {}
@@ -28,4 +34,15 @@ public final class UserClubMemberDto {
             LocalDateTime joinedAt,
             MemberStatus status
     ) {}
+    @Builder
+    public record ClubMemberDetailSearchResponse(
+            ClubProjection.ClubDetail club,
+            List<ClubMemberDetail> content,
+            PaginationInfo paginationInfo
+    ){}
+    @Builder
+    public record ClubMemberSearchResponse(
+            List<ClubSummary> content,
+            PaginationInfo paginationInfo
+    ){}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
@@ -10,11 +10,17 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 public class ClubProjection {
-    public record ClubSummery(
+    public record ClubSummary(
             Long id,
             String name,
             String affiliation,
             ClubStatus status,
             ClubMemberProjection.ClubMemberSummery clubMembers
+    ) {}
+    public record ClubDetail(
+            Long id,
+            String name,
+            String affiliation,
+            ClubStatus status
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubRepository.java
@@ -1,12 +1,15 @@
 package com.example.dgu_semi_erp_back.repository.club;
 import com.example.dgu_semi_erp_back.entity.club.Club;
-import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.*;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
     Optional<Club> findClubIdById(Long id);
-    Optional<ClubSummery> findClubById(Long id);
+    Optional<ClubSummary> findClubById(Long id);
+    Optional<ClubProjection.ClubDetail> findDetailByName(String name);
+    Optional<ClubProjection.ClubDetail> findDetailById(Long Id);
     Optional<Club> findByName(String name);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepository.java
@@ -2,10 +2,14 @@ package com.example.dgu_semi_erp_back.repository.peoplemanagement;
 
 
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
 import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserQueryRepository {
-    Page<ClubMemberDetail> findClubMembers(String clubName, ClubStatus status, Pageable pageable);
+public interface UserQueryRepository  extends JpaRepository<ClubMember, Long> {
+//    Page<ClubMember> findClubMembers(String clubName, ClubStatus status, Pageable pageable);
+    Page<ClubMember> findClubMembersByClubIdAndStatus(Long Id, MemberStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/peoplemanagement/UserQueryRepositoryImpl.java
@@ -1,55 +1,55 @@
-package com.example.dgu_semi_erp_back.repository.peoplemanagement;
-
-import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
-import com.example.dgu_semi_erp_back.entity.club.QClub;
-import com.example.dgu_semi_erp_back.entity.club.QClubMember;
-import com.example.dgu_semi_erp_back.entity.auth.user.QUser;
-import com.example.dgu_semi_erp_back.mapper.UserClubMemberMapper;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.*;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
-
-@Repository
-@RequiredArgsConstructor
-public class UserQueryRepositoryImpl implements UserQueryRepository {
-
-    private final JPAQueryFactory queryFactory;
-    private final UserClubMemberMapper mapper;
-
-    @Override
-    public Page<ClubMemberDetail> findClubMembers(String clubName, ClubStatus status, Pageable pageable) {
-        QClub club = QClub.club;
-        QClubMember cm = QClubMember.clubMember;
-        QUser user = QUser.user;
-
-        BooleanBuilder builder = new BooleanBuilder();
-        if (clubName != null) builder.and(club.name.eq(clubName));
-        if (status != null) builder.and(club.status.eq(status));
-
-        List<ClubMemberDetail> content = queryFactory
-                .selectFrom(cm)
-                .join(cm.club, club).fetchJoin()
-                .join(cm.user, user).fetchJoin()
-                .where(builder)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream()
-                .map(mapper::toDto)
-                .toList();
-
-        Long count = queryFactory
-                .select(cm.count())
-                .from(cm)
-                .join(cm.club, club)
-                .where(builder)
-                .fetchOne();
-
-        return new PageImpl<>(content, pageable, count != null ? count : 0);
-    }
-}
+//package com.example.dgu_semi_erp_back.repository.peoplemanagement;
+//
+//import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
+//import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+//import com.example.dgu_semi_erp_back.entity.club.QClub;
+//import com.example.dgu_semi_erp_back.entity.club.QClubMember;
+//import com.example.dgu_semi_erp_back.entity.auth.user.QUser;
+//import com.example.dgu_semi_erp_back.mapper.UserClubMemberMapper;
+//import com.querydsl.core.BooleanBuilder;
+//import com.querydsl.jpa.impl.JPAQueryFactory;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.data.domain.*;
+//import org.springframework.stereotype.Repository;
+//
+//import java.util.List;
+//
+//@Repository
+//@RequiredArgsConstructor
+//public class UserQueryRepositoryImpl implements UserQueryRepository {
+//
+//    private final JPAQueryFactory queryFactory;
+//    private final UserClubMemberMapper mapper;
+//
+//    @Override
+//    public Page<ClubMemberDetail> findClubMembers(String clubName, ClubStatus status, Pageable pageable) {
+//        QClub club = QClub.club;
+//        QClubMember cm = QClubMember.clubMember;
+//        QUser user = QUser.user;
+//
+//        BooleanBuilder builder = new BooleanBuilder();
+//        if (clubName != null) builder.and(club.name.eq(clubName));
+//        if (status != null) builder.and(club.status.eq(status));
+//
+//        List<ClubMemberDetail> content = queryFactory
+//                .selectFrom(cm)
+//                .join(cm.club, club).fetchJoin()
+//                .join(cm.user, user).fetchJoin()
+//                .where(builder)
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch()
+//                .stream()
+//                .map(mapper::toDto)
+//                .toList();
+//
+//        Long count = queryFactory
+//                .select(cm.count())
+//                .from(cm)
+//                .join(cm.club, club)
+//                .where(builder)
+//                .fetchOne();
+//
+//        return new PageImpl<>(content, pageable, count != null ? count : 0);
+//    }
+//}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
@@ -1,20 +1,76 @@
 package com.example.dgu_semi_erp_back.service.peoplemanagement;
 
+import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto;
+import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto;
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
-import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
+import com.example.dgu_semi_erp_back.entity.auth.user.QUser;
+import com.example.dgu_semi_erp_back.entity.club.*;
+import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
+import com.example.dgu_semi_erp_back.projection.club.ClubMemberProjection;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection;
+import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.repository.peoplemanagement.UserQueryRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserClubMemberService {
 
     private final UserQueryRepository queryRepository;
+    private final JPAQueryFactory queryFactory;
+    private final ClubRepository clubRepository;
 
-    public Page<ClubMemberDetail> getClubMembers(String clubName, ClubStatus status, Pageable pageable) {
-        return queryRepository.findClubMembers(clubName, status, pageable);
+    public UserClubMemberDto.ClubMemberDetailSearchResponse getClubMembers(Long clubId, String status, Pageable pageable) {
+        ClubProjection.ClubDetail club = clubRepository.findDetailById(clubId).orElseThrow(()-> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
+        Page<ClubMember> clubmemberPage = queryRepository.findClubMembersByClubIdAndStatus(clubId, MemberStatus.valueOf(status), pageable);
+        System.out.println(clubmemberPage.getContent().size());
+        QClub qClub = QClub.club;
+        QClubMember qMember = QClubMember.clubMember;
+        QUser qUser = QUser.user;
+
+        List<ClubMemberDetail> clubMemberDetails = queryFactory
+                .select(Projections.constructor(
+                        ClubMemberDetail.class,
+                        qUser.username,
+                        qUser.major,
+                        qUser.studentNumber,
+                        qMember.role,
+                        qMember.registeredAt,
+                        qMember.status
+                ))
+                .from(qMember)
+                .join(qUser).on(qMember.user.id.eq(qUser.id))
+                .join(qClub).on(qMember.club.id.eq(qClub.id))
+                .where(
+                        qMember.club.id.eq(clubId)
+                        .and(qMember.status.eq(MemberStatus.valueOf(status)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        System.out.println(clubMemberDetails);
+        return UserClubMemberDto.ClubMemberDetailSearchResponse.builder()
+                .club(club)
+                .content(clubMemberDetails)
+                .paginationInfo(
+                        new PaginationInfo(
+                                clubmemberPage.getNumber(),
+                                clubmemberPage.getSize(),
+                                clubmemberPage.getTotalPages(),
+                                clubmemberPage.getTotalElements()
+                        )
+                ).build();
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/user/UserUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/user/UserUseCase.java
@@ -1,12 +1,13 @@
 package com.example.dgu_semi_erp_back.usecase.user;
 
 import com.example.dgu_semi_erp_back.dto.club.ClubDto.ClubResponse;
+import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto;
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.ClubMemberDetail;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserResponse;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserRoleUpdateRequest;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserEmailUpdateRequest;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
-import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummery;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,5 +18,5 @@ public interface UserUseCase {
     User updateEmail(Long id, UserEmailUpdateRequest request, String accessToken, String refreshToken);
     User findUserByAccessToken(String accessToken);
     UserResponse getUserByToken(String accessToken);
-    Page<ClubSummery> getUserClubs(String accessToken, Pageable pageable);
+    UserClubMemberDto.ClubMemberSearchResponse getUserClubs(String accessToken, Pageable pageable);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
#44 

## 🔎 작업 내용
- 동아리원 조회 API 페이지네이션 개선
- 유저 동아리 조회 API 페이지네이션 개선

## 🔎 참고사항
- [동아리 멤버 조회 API](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt#9c02fc8a-b3c2-4cb0-9e8c-0f361aac260f)
- [유저 동아리 조회 API](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt#8ceb6000-36cc-47f5-9e0d-d7becdd93fba)