### PR TITLE
update: 유저 동아리 조회 API 동아리원 여러명 조회 하도록 개선

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
@@ -13,6 +13,9 @@ import java.time.LocalDateTime;
 public class ClubMemberProjection {
     public record ClubMemberSummery(
             Long id,
+            String name,
+            String major,
+            Integer studentNumber,
             Role role,
             MemberStatus status,
             LocalDateTime registeredAt

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
@@ -8,6 +8,8 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ClubProjection {
     public record ClubSummary(
@@ -15,7 +17,7 @@ public class ClubProjection {
             String name,
             String affiliation,
             ClubStatus status,
-            ClubMemberProjection.ClubMemberSummery clubMembers
+            List<ClubMemberProjection.ClubMemberSummery> clubMembers
     ) {}
     public record ClubDetail(
             Long id,


### PR DESCRIPTION
## 🔎 관련 이슈
closed #54 

## 🔎 작업 내용
- 유저 동아리 조회 API가 동아리원을 여러명 조회할 수 있도록 개선


## 🔎 참고사항
![image](https://github.com/user-attachments/assets/dbcf5166-8537-4706-83f3-88786173119b)
