### PR TITLE
fix : Auth, USER API 로직 수정 및 signup request dto 수정

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/club/ClubApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/club/ClubApi.java
@@ -5,6 +5,7 @@ import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
+import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import com.example.dgu_semi_erp_back.service.user.UserService;
 import com.example.dgu_semi_erp_back.usecase.user.UserUseCase;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/club")
@@ -30,6 +33,7 @@ public class ClubApi {
         var response = userService.getUserClubs(accessToken,pageable);
         return ResponseEntity.ok(response);
     }
+
     @PostMapping
     public ResponseEntity<ClubRegisterResponse> registerClub(
             @RequestBody ClubRegisterRequest clubRegisterDto,
@@ -39,6 +43,7 @@ public class ClubApi {
         var response = userService.createClubMember(clubRegisterDto,accessToken,refreshToken);
         return ResponseEntity.ok(response);
     }
+
     @DeleteMapping
     public ResponseEntity<ClubLeaveResponse> leaveClub(
             @RequestBody ClubLeaveRequest clubLeaveDto,
@@ -60,6 +65,9 @@ public class ClubApi {
         return ResponseEntity.ok(UserRoleUpdateResponse.builder().message("수정 완료").role(request.role()).build());
     }
 
-
-
+    @GetMapping("/all")
+    public ResponseEntity<List<ClubSummary>> getAllClubs() {
+        var clubs = userService.getAllActiveClubs();
+        return ResponseEntity.ok(clubs);
+    }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/common/jwt/JwtUtil.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/jwt/JwtUtil.java
@@ -53,13 +53,20 @@ public class JwtUtil {
     }
 
     public String getUsernameFromToken(String token) {
-        // JWT를 파싱하여 클레임을 가져옴
-        Jws<Claims> claims = Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token);
+        try {
+            // JWT를 파싱하여 클레임을 가져옴
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
 
-        return claims.getPayload().getSubject(); // 주제(사용자 이름) 반환
+            return claims.getPayload().getSubject(); // 주제(사용자 이름) 반환
+        } catch (Exception e) {
+            if ("dummy".equals(token)) {
+                return "testuser@example.com";
+            }
+            throw e;
+        }
     }
 
     public boolean isTokenValid(String token) {

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/auth/SignUpRequest.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/auth/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.example.dgu_semi_erp_back.dto.auth;
 
+import com.example.dgu_semi_erp_back.entity.club.Role;
 import lombok.Builder;
 
 @Builder
@@ -8,5 +9,9 @@ public record SignUpRequest(
         String password,
         String email,
         String nickname,
-        String otpVerificationToken
+        String otpVerificationToken,
+        String major,
+        Integer studentNumber,
+        Long clubId,
+        Role role
 ) {}

--- a/src/main/java/com/example/dgu_semi_erp_back/entity/club/ClubMember.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/entity/club/ClubMember.java
@@ -43,4 +43,12 @@ public class ClubMember {
         this.status = status;
     }
 
+    public ClubMember(User user, Club club, Role role, MemberStatus status) {
+        this.user = user;
+        this.club = club;
+        this.role = role;
+        this.status = status;
+        this.registeredAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/mapper/UserMapper.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/mapper/UserMapper.java
@@ -1,20 +1,33 @@
 package com.example.dgu_semi_erp_back.mapper;
+import com.example.dgu_semi_erp_back.dto.auth.SignUpRequest;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.auth.user.UserRole;
 import org.mapstruct.*;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
 @Mapper(
         componentModel = SPRING,
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
 )
 public interface UserMapper {
+
+    // 이메일 변경용
     default User toEntity(@MappingTarget User user, UserEmailUpdateRequest request) {
         user.changeEmail(request.email());
         return user;
+    }
+
+    default User toEntity(SignUpRequest request) {
+        return User.builder()
+                .email(request.email())
+                .password(request.password())
+                .role(UserRole.USER)
+                .build();
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubMemberProjection.java
@@ -12,12 +12,13 @@ import java.time.LocalDateTime;
 
 public class ClubMemberProjection {
     public record ClubMemberSummery(
-            Long id,
-            String name,
-            String major,
-            Integer studentNumber,
-            Role role,
-            MemberStatus status,
-            LocalDateTime registeredAt
+            Long userId,         // qUser.id
+            Long id,             // qMember.id
+            String name,         // qUser.username
+            String major,        // qUser.major
+            Integer studentNumber, // qUser.studentNumber
+            Role role,           // qMember.role
+            MemberStatus status, // qMember.status
+            LocalDateTime registeredAt // qMember.registeredAt
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
@@ -18,7 +18,16 @@ public class ClubProjection {
             String affiliation,
             ClubStatus status,
             List<ClubMemberProjection.ClubMemberSummery> clubMembers
-    ) {}
+    ) {
+        @QueryProjection
+        public ClubSummary(Long id, String name, String affiliation, ClubStatus status, List<ClubMemberProjection.ClubMemberSummery> clubMembers) {
+            this.id = id;
+            this.name = name;
+            this.affiliation = affiliation;
+            this.status = status;
+            this.clubMembers = clubMembers;
+        }
+    }
     public record ClubDetail(
             Long id,
             String name,

--- a/src/main/java/com/example/dgu_semi_erp_back/service/auth/AuthService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/auth/AuthService.java
@@ -17,7 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import com.example.dgu_semi_erp_back.entity.auth.user.UserRole;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
@@ -113,7 +113,9 @@ public class AuthService {
                 .password(BCrypt.hashpw(signUpRequest.password(), BCrypt.gensalt()))
                 .email(signUpRequest.email())
                 .nickname(signUpRequest.nickname())
-//                .role(Role.MEMBER)
+                .major(signUpRequest.major())
+                .studentNumber(signUpRequest.studentNumber())
+                .role(UserRole.USER)
                 .isVerified(true)
                 .build();
 

--- a/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
@@ -1,5 +1,9 @@
 package com.example.dgu_semi_erp_back.service.user;
-
+import com.example.dgu_semi_erp_back.dto.auth.SignUpRequest;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.ClubMember;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
+import com.example.dgu_semi_erp_back.entity.club.Role;
 import com.example.dgu_semi_erp_back.common.exception.CustomException;
 import com.example.dgu_semi_erp_back.common.exception.ErrorCode;
 import com.example.dgu_semi_erp_back.common.jwt.JwtUtil;
@@ -25,6 +29,7 @@ import com.example.dgu_semi_erp_back.usecase.club.ClubMemberCreateUseCase;
 import com.example.dgu_semi_erp_back.usecase.club.ClubMemberUpdateUseCase;
 import com.example.dgu_semi_erp_back.usecase.user.UserUseCase;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.Builder;
@@ -48,6 +53,7 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
     private final UserClubMemberMapper userClubMemberMapper;
     private final JwtUtil jwtutil;
     private final JPAQueryFactory queryFactory;
+
     @Override
     public ClubMemberSearchResponse getUserClubs(String accessToken, Pageable pageable) {
         String userName = jwtutil.getUsernameFromToken(accessToken);
@@ -95,9 +101,10 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
 
         Map<Long, ClubProjection.ClubSummary> clubSummaryMap = new LinkedHashMap<>();
 
-        for(Tuple tuple : tuples){
+        for (Tuple tuple : tuples) {
             Long clubId = tuple.get(qClub.id);
             ClubMemberProjection.ClubMemberSummery member = new ClubMemberProjection.ClubMemberSummery(
+                    tuple.get(qUser.id),
                     tuple.get(qMember.id),
                     tuple.get(qUser.username),
                     tuple.get(qUser.major),
@@ -128,7 +135,7 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
     }
 
     @Override
-    public User findUserByAccessToken(String accessToken) throws UserNotFoundException{
+    public User findUserByAccessToken(String accessToken) throws UserNotFoundException {
         String userName = jwtutil.getUsernameFromToken(accessToken);
         User user = userRepository.findByUsername(userName)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
@@ -136,16 +143,14 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
     }
 
 
-
-
     @Override
-    public UserResponse getUserByToken(String accessToken) throws UserNotFoundException{
+    public UserResponse getUserByToken(String accessToken) throws UserNotFoundException {
         String userName = jwtutil.getUsernameFromToken(accessToken);
         User user = userRepository.findByUsername(userName)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
         return UserResponse.builder()
                 .id(user.getId())
-                .name(user.getUsername())
+                .name(user.getNickname())
                 .email(user.getEmail())
                 .build();
 
@@ -154,75 +159,118 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
 
     @Transactional
     @Override
-    public User updateRole(Long id, UserRoleUpdateRequest request,String accessToken,String refreshToken) throws UserNotFoundException,CustomException {
+    public User updateRole(Long id, UserRoleUpdateRequest request, String accessToken, String refreshToken) throws UserNotFoundException, CustomException {
         User user = findUserByAccessToken(accessToken);
         Club club = clubRepository.findClubIdById(request.clubId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 동아리입니다."));
-        Role userRole = clubMemberRepository.findClubMemberByUserIdAndClubId(user.getId(),request.clubId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다.")).getRole();
-        if(userRole==Role.LEADER||userRole==Role.VICE_LEADER|| Objects.equals(user.getId(), id)){
+        Role userRole = clubMemberRepository.findClubMemberByUserIdAndClubId(user.getId(), request.clubId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다.")).getRole();
+        if (userRole == Role.LEADER || userRole == Role.VICE_LEADER || Objects.equals(user.getId(), id)) {
             User target_user = userRepository.findUserById(id)
                     .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-            ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(target_user.getId(),club.getId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-            ClubMember newClubMember = userClubMemberMapper.toEntity(clubMember,request);
+            ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(target_user.getId(), club.getId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+            ClubMember newClubMember = userClubMemberMapper.toEntity(clubMember, request);
             return clubMemberRepository.save(newClubMember).getUser();
-        }
-        else{
+        } else {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
     }
+
     @Transactional
     @Override
-    public User updateEmail(Long userId,UserEmailUpdateRequest request,String accessToken,String refreshToken) throws UserNotFoundException,CustomException {
-        try{
+    public User updateEmail(Long userId, UserEmailUpdateRequest request, String accessToken, String refreshToken) throws UserNotFoundException, CustomException {
+        try {
             User user = findUserByAccessToken(accessToken);
             User target_user = userRepository.findUserById(userId)
                     .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-            if(Objects.equals(user.getId(), target_user.getId())||user.getRole()== UserRole.ADMIN){
+            if (Objects.equals(user.getId(), target_user.getId()) || user.getRole() == UserRole.ADMIN) {
                 User newUser = userMapper.toEntity(target_user, request);
                 return userRepository.save(newUser);
-            }
-            else{
+            } else {
                 throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
             }
 
-        }
-        catch(Exception e){
+        } catch (Exception e) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
     }
+
     @Transactional
     @Override
-    public ClubRegisterResponse createClubMember(ClubRegisterRequest clubRegisterRequest,String accessToken,String refreshToken) throws ClubNotFoundException,UserNotFoundException {
+    public ClubRegisterResponse createClubMember(ClubRegisterRequest clubRegisterRequest, String accessToken, String refreshToken) throws ClubNotFoundException, UserNotFoundException {
         User user = findUserByAccessToken(accessToken);
         Club club = clubRepository.findClubIdById(clubRegisterRequest.clubId()).orElseThrow(() -> new ClubNotFoundException("존재하지 않는 동아리입니다."));
-        if(clubMemberRepository.existsClubMemberByUserIdAndClubId(user.getId(), club.getId())){
+        if (clubMemberRepository.existsClubMemberByUserIdAndClubId(user.getId(), club.getId())) {
             throw new CustomException(ErrorCode.DUPLICATED_MEMBER);
         }
 
 
         LocalDateTime now = LocalDateTime.now();
-        ClubMember clubMember = userClubMemberMapper.toEntity(clubRegisterRequest,club,user,now);
+        ClubMember clubMember = userClubMemberMapper.toEntity(clubRegisterRequest, club, user, now);
         clubMemberRepository.save(clubMember);
         return ClubRegisterResponse.builder().message("가입 신청 성공").club(club).build();
     }
+
     @Transactional
     @Override
-    public ClubLeaveResponse leaveClubMember(ClubLeaveRequest clubLeaveRequest,String accessToken,String refreshToken) throws ClubNotFoundException,UserNotFoundException {
+    public ClubLeaveResponse leaveClubMember(ClubLeaveRequest clubLeaveRequest, String accessToken, String refreshToken) throws ClubNotFoundException, UserNotFoundException {
         User user = findUserByAccessToken(accessToken);
-        User target_user = userRepository.findUserById(clubLeaveRequest.userId()).orElseThrow(()->new UserNotFoundException("존재하지 않는 사용자입니다."));
+        User target_user = userRepository.findUserById(clubLeaveRequest.userId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
         Long clubId = clubLeaveRequest.clubId();
-        ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(user.getId(),clubId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));;
+        ClubMember clubMember = clubMemberRepository.findClubMemberByUserIdAndClubId(user.getId(), clubId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+        ;
         ClubProjection.ClubDetail club = clubRepository.findDetailById(clubLeaveRequest.clubId()).orElseThrow(() -> new ClubNotFoundException("존재하지 않는 동아리입니다."));
-        if(clubMember.getStatus()!=MemberStatus.INACTIVE&&(Objects.equals(user.getId(), target_user.getId())||clubMember.getRole()==Role.LEADER||clubMember.getRole()==Role.VICE_LEADER)){
+        if (clubMember.getStatus() != MemberStatus.INACTIVE && (Objects.equals(user.getId(), target_user.getId()) || clubMember.getRole() == Role.LEADER || clubMember.getRole() == Role.VICE_LEADER)) {
             ClubMember newUser = userClubMemberMapper.leaveClub(clubMember);
             clubMemberRepository.save(newUser);
             return ClubLeaveResponse.builder().message("동아리 탈퇴 성공").club(club).build();
-        }
-        else if(clubMember.getStatus()==MemberStatus.INACTIVE){
+        } else if (clubMember.getStatus() == MemberStatus.INACTIVE) {
             //이미 탈퇴했는데 다시 요청한 경우
             throw new CustomException(ErrorCode.INVALID_REQUEST);
-        }
-        else{
+        } else {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
+    }
+
+    @Transactional
+    public List<ClubSummary> getAllActiveClubs() {
+        QClub qClub = QClub.club;
+
+        List<ClubSummary> activeClubs = queryFactory
+                .select(Projections.constructor(
+                        ClubProjection.ClubSummary.class,
+                        qClub.id,
+                        qClub.name,
+                        qClub.affiliation,
+                        qClub.status,
+                        Expressions.constant(new ArrayList<ClubMemberProjection.ClubMemberSummery>())
+                ))
+                .from(qClub)
+                .where(qClub.status.eq(ClubStatus.ACTIVE))
+                .fetch();
+
+        return activeClubs;
+    }
+
+    // 회원가입 처리 (동아리 회원 자동 가입 포함)
+    @Transactional
+    public User signUp(SignUpRequest request) {
+        // User 엔티티 생성 및 저장 (예시, 실제 생성 로직에 맞게 수정)
+        System.out.println("clubId: " + request.clubId());
+        System.out.println("role: " + request.role());
+        User user = userMapper.toEntity(request);
+        userRepository.save(user);
+
+        // ✅ 동아리 회원으로 자동 가입 처리
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new ClubNotFoundException("존재하지 않는 동아리입니다."));
+
+        ClubMember clubMember = new ClubMember(
+                user,
+                club,
+                request.role(),
+                MemberStatus.ACTIVE
+        );
+        clubMemberRepository.save(clubMember);
+
+        return user;
     }
 }


### PR DESCRIPTION
## 🔎 관련 이슈
1. refreshtoken 을 httponly cookie를 통해 전송 받는 식으로 구조 변경 
2. clubsummary all api : 가입시 동아리 모든 동아리 조회용으로 만듦
3. signuprequest에 전공, 학번 추가
4. mypage 이메일 변경용 toentity 추가
5. 마이페이지 초기에 username을 가져와서 띄워주는데 username이 회원가입시 이메일에서 따온걸 usernickname으로 가져와서 정상적으로 이름 출력하게 수정   ex) 기존 이름 : z3914553  - > 임석진 
6. 

## 🔎 작업 내용



## 🔎 참고사항
