### PR TITLE
feature: 통장을 보유한 동아리 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
@@ -1,10 +1,12 @@
 package com.example.dgu_semi_erp_back.api.account;
 
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountClubListResponse;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdateRequest;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountInfoResponse;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountInfoDetailResponse;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateResponse;
+import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateResponse.ClubInfo;
 import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
 import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
 import com.example.dgu_semi_erp_back.exception.AccountNotFoundException;
@@ -53,6 +55,36 @@ public class AccountApi {
         var account = accountUseCase.createAccount(request, username);
 
         return accountMapper.toAccountCreateResponse(account);
+    }
+
+    /**
+     * 통장을 보유한 동아리 목록 조회
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     */
+    @GetMapping("/clubs")
+    @ResponseStatus(HttpStatus.OK)
+    public AccountClubListResponse getClubsWithAccounts(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "8") int size
+    ) {
+        var pagedAccounts = accountUseCase.getPagedAccounts(page, size);
+
+        return AccountClubListResponse.builder()
+                .clubs(pagedAccounts.getContent().stream()
+                                .map(club -> new ClubInfo(
+                                        club.getId(),
+                                        club.getName(),
+                                        club.getAffiliation()
+                                ))
+                                .toList())
+                .paginationInfo(new PaginationInfo(
+                        pagedAccounts.getNumber(),
+                        pagedAccounts.getSize(),
+                        pagedAccounts.getTotalPages(),
+                        pagedAccounts.getTotalElements()
+                ))
+                .build();
     }
 
     /**

--- a/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/account/AccountApi.java
@@ -88,7 +88,7 @@ public class AccountApi {
     }
 
     /**
-     * 통장 정보 조회
+     * 통장 정보 상세 조회
      * @param clubId 동아리 ID
      * @return AccountInfoResponse 통장 번호, 개설일, 소유주 이름, 동아리 이름, (List)통장 거래 내역, PaginationInfo
      */
@@ -98,7 +98,7 @@ public class AccountApi {
             @PathVariable("clubId") Long clubId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "7") int size
-            ) {
+    ){
         try {
             var account = accountUseCase.getAccountByClubId(clubId);
             var pagedHistories = accountUseCase.getPagedAccountHistories(account.getId(), page, size);
@@ -108,7 +108,7 @@ public class AccountApi {
                     .createdAt(account.getCreatedAt())
                     .ownerName(account.getUser().getUsername())
                     .clubName(account.getClub().getName())
-                    .accountHistories(account.getAccountHistories().stream()
+                    .accountHistories(pagedHistories.getContent().stream()
                             .map(history -> new AccountHistoryDetailResponse(
                                     history.getPayType(),
                                     history.getContent(),

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/account/AccountCommandDto.java
@@ -1,14 +1,12 @@
 package com.example.dgu_semi_erp_back.dto.account;
 
 import com.example.dgu_semi_erp_back.dto.common.PaginationInfo;
-import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.dto.account.AccountHistoryCommandDto.AccountHistoryDetailResponse;
 import com.example.dgu_semi_erp_back.entity.auth.user.UserRole;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public final class AccountCommandDto {
@@ -76,6 +74,12 @@ public final class AccountCommandDto {
             String ownerName,
             String clubName,
             List<AccountHistoryDetailResponse> accountHistories,
+            PaginationInfo paginationInfo
+    ) {}
+
+    @Builder
+    public record AccountClubListResponse(
+            List<AccountCreateResponse.ClubInfo> clubs,
             PaginationInfo paginationInfo
     ) {}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubQueryRepository.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubQueryRepository.java
@@ -1,0 +1,9 @@
+package com.example.dgu_semi_erp_back.repository.club;
+
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ClubQueryRepository {
+    Page<Club> getPagedAccounts(Pageable pageable);
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/repository/club/ClubQueryRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.example.dgu_semi_erp_back.repository.club;
+
+import com.example.dgu_semi_erp_back.entity.account.QAccount;
+import com.example.dgu_semi_erp_back.entity.club.Club;
+import com.example.dgu_semi_erp_back.entity.club.QClub;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ClubQueryRepositoryImpl implements ClubQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 통장을 보유한 동아리 목록 조회
+     * - account 정보를 보유한 동아리 목록을 페이지 단위로 조회
+     */
+    @Override
+    public Page<Club> getPagedAccounts(Pageable pageable) {
+        QClub club = QClub.club;
+        QAccount account = QAccount.account;
+        Instant now = Instant.now();
+
+        List<Club> clubs = queryFactory
+                .selectFrom(club)
+                .where(
+                        queryFactory
+                                .selectOne()
+                                .from(account)
+                                .where(
+                                        account.club.eq(club),
+                                        account.deletedAt.isNull()
+                                                .or(account.deletedAt.gt(now))
+                                )
+                                .exists()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .selectFrom(club)
+                .where(
+                        queryFactory
+                                .selectOne()
+                                .from(account)
+                                .where(
+                                        account.club.eq(club),
+                                        account.deletedAt.isNull()
+                                                .or(account.deletedAt.gt(now))
+                                )
+                                .exists()
+                )
+                .fetchCount();
+
+        return new PageImpl<>(clubs, pageable, total);
+    }
+}

--- a/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/account/AccountCommandService.java
@@ -20,6 +20,7 @@ import com.example.dgu_semi_erp_back.repository.account.AccountHistoryQueryRepos
 import com.example.dgu_semi_erp_back.repository.account.AccountQueryRepository;
 import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubMemberRepository;
+import com.example.dgu_semi_erp_back.repository.club.ClubQueryRepository;
 import com.example.dgu_semi_erp_back.repository.club.ClubRepository;
 import com.example.dgu_semi_erp_back.service.notification.NotificationService;
 import com.example.dgu_semi_erp_back.entity.notification.Category;
@@ -46,6 +47,7 @@ public class AccountCommandService implements AccountUseCase {
     private final AccountHistoryQueryRepository accountHistoryQueryRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
+    private final ClubQueryRepository clubQueryRepository;
     private final EntityManager entityManager;
     private final AccountMapper accountMapper;
     private final ClubMemberRepository clubMemberRepository;
@@ -212,5 +214,17 @@ public class AccountCommandService implements AccountUseCase {
             "통장이 삭제되었습니다",
             account.getClub().getName() + " 동아리의 통장이 삭제되었습니다."
         );
+    }
+
+    /**
+     * 통장을 보유한 동아리 목록 조회
+     * - account 정보를 보유한 동아리 목록을 페이지 단위로 조회
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     */
+    @Override
+    public Page<Club> getPagedAccounts(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return clubQueryRepository.getPagedAccounts(pageable);
     }
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/account/AccountUseCase.java
@@ -4,19 +4,28 @@ import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountUpdate
 import com.example.dgu_semi_erp_back.dto.account.AccountCommandDto.AccountCreateRequest;
 import com.example.dgu_semi_erp_back.entity.account.Account;
 import com.example.dgu_semi_erp_back.entity.account.AccountHistory;
+import com.example.dgu_semi_erp_back.entity.club.Club;
 import org.springframework.data.domain.Page;
 
 public interface AccountUseCase {
     Account createAccount(AccountCreateRequest request, String username);
     Account getAccountByClubId(Long clubId);
+
     Page<AccountHistory> getPagedAccountHistories(
             Long accountId,
             int page,
             int size
     );
+
     Account updateAccount(
             Long accountId,
             AccountUpdateRequest request
     );
+
     void deleteAccount(Long accountId);
+
+    Page<Club> getPagedAccounts(
+            int page,
+            int size
+    );
 }


### PR DESCRIPTION
## 🔎 관련 이슈
closed #62 

## 🔎 작업 내용
- 통장 상세 내역 조회 로직 오류 개선
- 통장을 보유한 동아리 목록 조회 api 구현
   - 통장 소프트딜리트 고려하여 로직 구현
   - 페이지네이션 테스트 완료


## 🔎 참고사항
![스크린샷 2025-06-24 16 12 26](https://github.com/user-attachments/assets/ae970e68-9c2e-4e9a-ad1f-fb2a3716dbc9)
