### PR TITLE
Update: 동아리 목록 조회 API 조건 필터링 기능 개선

### DIFF
--- a/src/main/java/com/example/dgu_semi_erp_back/api/club/ClubApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/club/ClubApi.java
@@ -3,6 +3,8 @@ package com.example.dgu_semi_erp_back.api.club;
 import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.*;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
 import com.example.dgu_semi_erp_back.service.peoplemanagement.UserClubMemberService;
@@ -34,15 +36,6 @@ public class ClubApi {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping
-    public ResponseEntity<ClubMemberSearchResponse> getClubs(
-            @PageableDefault(size = 5) Pageable pageable,
-            HttpServletRequest req
-    ){
-        String username = (String) req.getAttribute("username");
-        var response = userService.getUserClubs(username,pageable);
-        return ResponseEntity.ok(response);
-    }
     @PostMapping
     public ResponseEntity<ClubRegisterResponse> registerClub(
             @RequestBody ClubRegisterRequest clubRegisterDto,

--- a/src/main/java/com/example/dgu_semi_erp_back/api/user/UserApi.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/api/user/UserApi.java
@@ -4,6 +4,7 @@ import com.example.dgu_semi_erp_back.dto.club.UserClubMemberDto.*;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.*;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
 import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.exception.ClubNotFoundException;
 import com.example.dgu_semi_erp_back.exception.UserNotFoundException;
 import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
@@ -41,10 +42,30 @@ public class UserApi {
     @GetMapping("/me/club")
     public ResponseEntity<ClubMemberSearchResponse> getClubs(
             @PageableDefault(size = 5) Pageable pageable,
+            @RequestParam(required = false) Long currentPeopleMin,
+            @RequestParam(required = false) Long currentPeopleMax,
+            @RequestParam(required = false) Long totalPeopleMin,
+            @RequestParam(required = false) Long totalPeopleMax,
+            @RequestParam(required = false) String clubName,
+            @RequestParam(required = false) ClubStatus status,
             HttpServletRequest request
     ){
         String username = (String) request.getAttribute("username");
-        var response = userService.getUserClubs(username,pageable);
+        var response = userService.getUserClubs(username,currentPeopleMin,currentPeopleMax,totalPeopleMin,totalPeopleMax,clubName,status,pageable);
+        return ResponseEntity.ok(response);
+    }
+    @GetMapping("/me/club/all")
+    public ResponseEntity<ClubSearchResponse> getAllClubs(
+            @RequestParam(required = false) Long currentPeopleMin,
+            @RequestParam(required = false) Long currentPeopleMax,
+            @RequestParam(required = false) Long totalPeopleMin,
+            @RequestParam(required = false) Long totalPeopleMax,
+            @RequestParam(required = false) String clubName,
+            @RequestParam(required = false) ClubStatus status,
+            HttpServletRequest req
+    ){
+        String username = (String) req.getAttribute("username");
+        var response = userService.getAllClubs(username,currentPeopleMin,currentPeopleMax,totalPeopleMin,totalPeopleMax,clubName,status);
         return ResponseEntity.ok(response);
     }
     @PostMapping("/me/club")

--- a/src/main/java/com/example/dgu_semi_erp_back/common/config/WebConfig.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/common/config/WebConfig.java
@@ -16,6 +16,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/post/**")
                 .addPathPatterns("/account/protected/**") // 통장관리 API
+                .addPathPatterns("/user/**")
+                .addPathPatterns("/club/**")
         ; // JWT 인가가 필요한 경로 설정
     }
 

--- a/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/dto/club/UserClubMemberDto.java
@@ -50,4 +50,8 @@ public final class UserClubMemberDto {
             List<ClubSummary> content,
             PaginationInfo paginationInfo
     ){}
+    @Builder
+    public record ClubSearchResponse(
+            List<ClubProjection.ClubDetail> content
+    ){}
 }

--- a/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/projection/club/ClubProjection.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ClubProjection {
+    @Builder
     public record ClubSummary(
             Long id,
             String name,

--- a/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/peoplemanagement/UserClubMemberService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -31,7 +32,10 @@ public class UserClubMemberService {
     private final JPAQueryFactory queryFactory;
     private final ClubRepository clubRepository;
 
-    public UserClubMemberDto.ClubMemberDetailSearchResponse getClubMembers(Long clubId, String status, Pageable pageable) {
+    public UserClubMemberDto.ClubMemberDetailSearchResponse getClubMembers(
+            Long clubId,
+            String status,
+            Pageable pageable) {
         ClubProjection.ClubDetail club = clubRepository.findDetailById(clubId).orElseThrow(()-> new ClubNotFoundException("해당 동아리가 존재하지 않습니다."));
         Page<ClubMember> clubmemberPage;
         if(status!=null) {

--- a/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/service/user/UserService.java
@@ -24,8 +24,13 @@ import com.example.dgu_semi_erp_back.repository.auth.UserRepository;
 import com.example.dgu_semi_erp_back.usecase.club.ClubMemberCreateUseCase;
 import com.example.dgu_semi_erp_back.usecase.club.ClubMemberUpdateUseCase;
 import com.example.dgu_semi_erp_back.usecase.user.UserUseCase;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +39,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.RequestParam;
+
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -49,47 +56,141 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
     private final JwtUtil jwtutil;
     private final JPAQueryFactory queryFactory;
     @Override
-    public ClubMemberSearchResponse getUserClubs(String username, Pageable pageable) {
+    public ClubMemberSearchResponse getUserClubs(
+            String username,
+            Long currentPeopleMin,
+            Long currentPeopleMax,
+            Long totalPeopleMin,
+            Long totalPeopleMax,
+            String clubName,
+            ClubStatus status,
+            Pageable pageable) {
+        // pageable이 null이면 전체 조회
+        boolean isUnpaged = (pageable == null);
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
 
-        List<Long> userClubIds = clubMemberRepository.findClubIdsByUserId(user.getId()).stream()
-                .map(cm -> cm.getClub().getId())
-                .collect(Collectors.toList());
+        QClubMember cm = QClubMember.clubMember;
+        QClub club = QClub.club;
 
-        if (userClubIds.isEmpty()) {
-            return ClubMemberSearchResponse.builder()
-                    .content(new ArrayList<>())
-                    .paginationInfo(new PaginationInfo(
-                            pageable.getPageNumber(),
-                            pageable.getPageSize(),
-                            0,
-                            0
-                    ))
-                    .build();
-        }
-
-        QClub qClub = QClub.club;
-
-        List<Long> pagedClubIds = queryFactory
-                .select(qClub.id)
-                .from(qClub)
-                .where(qClub.id.in(userClubIds))
-                .orderBy(qClub.id.asc()) // 정렬 기준 명시
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+        List<Long> userClubIds = queryFactory
+                .select(cm.club.id)
+                .from(cm)
+                .where(cm.user.id.eq(user.getId()))
                 .fetch();
 
-        if (pagedClubIds.isEmpty()) {
-            return ClubMemberSearchResponse.builder()
-                    .content(new ArrayList<>())
-                    .paginationInfo(new PaginationInfo(
-                            pageable.getPageNumber(),
-                            pageable.getPageSize(),
-                            0,
-                            0
-                    ))
-                    .build();
+        Map<Long, Long> currentPeopleMap = queryFactory
+                .select(cm.club.id, cm.count())
+                .from(cm)
+                .where(cm.status.eq(MemberStatus.ACTIVE))
+                .groupBy(cm.club.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Long.class),
+                        tuple -> tuple.get(1, Long.class)
+                ));
+
+        Map<Long, Long> totalPeopleMap = queryFactory
+                .select(cm.club.id, cm.count())
+                .from(cm)
+                .groupBy(cm.club.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Long.class),
+                        tuple -> tuple.get(1, Long.class)
+                ));
+
+        List<Long> filteredClubIds = userClubIds.stream()
+                .filter(id -> {
+                    long current = currentPeopleMap.getOrDefault(id, 0L);
+                    long total = totalPeopleMap.getOrDefault(id, 0L);
+                    return (currentPeopleMin == null || current >= currentPeopleMin) &&
+                            (currentPeopleMax == null || current <= currentPeopleMax) &&
+                            (totalPeopleMin == null || total >= totalPeopleMin) &&
+                            (totalPeopleMax == null || total <= totalPeopleMax);
+                })
+                .collect(Collectors.toList());
+
+        if (filteredClubIds.isEmpty()) {
+            if(isUnpaged) {
+                return ClubMemberSearchResponse.builder()
+                        .content(new ArrayList<>())
+                        .paginationInfo(new PaginationInfo(
+                                0,
+                                0,
+                                0,
+                                0
+                        ))
+                        .build();
+            }
+            else{
+                return ClubMemberSearchResponse.builder()
+                        .content(new ArrayList<>())
+                        .paginationInfo(new PaginationInfo(
+                                pageable.getPageNumber(),
+                                pageable.getPageSize(),
+                                0,
+                                0
+                        ))
+                        .build();
+            }
+        }
+
+        BooleanBuilder clubFilter = new BooleanBuilder();
+        clubFilter.and(club.id.in(filteredClubIds));
+        if(clubName != null && !clubName.isBlank()) {
+            clubFilter.and(club.name.eq(clubName));
+        }
+        if(status != null) {
+            clubFilter.and(club.status.eq(status));
+        }
+        List<Long> pagedClubIds;
+        if(isUnpaged) {
+            pagedClubIds = queryFactory
+                    .select(club.id)
+                    .from(club)
+                    .where(clubFilter)
+                    .orderBy(club.id.asc())
+                    .fetch();
+        }
+        else{
+            pagedClubIds = queryFactory
+                    .select(club.id)
+                    .from(club)
+                    .where(clubFilter)
+                    .orderBy(club.id.asc())
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+        }
+
+
+        if(pagedClubIds.isEmpty()) {
+            if(isUnpaged) {
+                return ClubMemberSearchResponse.builder()
+                        .content(new ArrayList<>())
+                        .paginationInfo(new PaginationInfo(
+                                0,
+                                0,
+                                0,
+                                0
+                        ))
+                        .build();
+            }
+            else{
+                return ClubMemberSearchResponse.builder()
+                        .content(new ArrayList<>())
+                        .paginationInfo(new PaginationInfo(
+                                pageable.getPageNumber(),
+                                pageable.getPageSize(),
+                                0,
+                                0
+                        ))
+                        .build();
+            }
+
         }
 
         QClubMember qMember = QClubMember.clubMember;
@@ -97,10 +198,10 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
 
         List<Tuple> tuples = queryFactory
                 .select(
-                        qClub.id,
-                        qClub.name,
-                        qClub.affiliation,
-                        qClub.status,
+                        club.id,
+                        club.name,
+                        club.affiliation,
+                        club.status,
                         qMember.id,
                         qUser.username,
                         qUser.major,
@@ -109,17 +210,17 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
                         qMember.status,
                         qMember.registeredAt
                 )
-                .from(qClub)
-                .join(qMember).on(qMember.club.id.eq(qClub.id))
+                .from(club)
+                .join(qMember).on(qMember.club.id.eq(club.id))
                 .join(qUser).on(qMember.user.id.eq(qUser.id))
-                .where(qClub.id.in(pagedClubIds))
-                .orderBy(qClub.id.asc())
+                .where(club.id.in(pagedClubIds))
+                .orderBy(club.id.asc())
                 .fetch();
 
         Map<Long, ClubProjection.ClubSummary> clubSummaryMap = new LinkedHashMap<>();
 
         for (Tuple tuple : tuples) {
-            Long clubId = tuple.get(qClub.id);
+            Long clubId = tuple.get(club.id);
             ClubMemberProjection.ClubMemberSummery member = new ClubMemberProjection.ClubMemberSummery(
                     tuple.get(qMember.id),
                     tuple.get(qUser.username),
@@ -129,27 +230,172 @@ public class UserService implements UserUseCase, ClubMemberCreateUseCase, ClubMe
                     tuple.get(qMember.status),
                     tuple.get(qMember.registeredAt)
             );
+
             clubSummaryMap.computeIfAbsent(clubId, id -> new ClubProjection.ClubSummary(
-                    tuple.get(qClub.id),
-                    tuple.get(qClub.name),
-                    tuple.get(qClub.affiliation),
-                    tuple.get(qClub.status),
+                    tuple.get(club.id),
+                    tuple.get(club.name),
+                    tuple.get(club.affiliation),
+                    tuple.get(club.status),
                     new ArrayList<>()
             ));
             clubSummaryMap.get(clubId).clubMembers().add(member);
         }
+        int totalClubs;
+        if(status==null){
+            totalClubs = totalPeopleMap.size();
+        }
+        else if(status==ClubStatus.ACTIVE){
+            totalClubs = currentPeopleMap.size();
+        }
+        else{
+            totalClubs = totalPeopleMap.size()-currentPeopleMap.size();
+        }
+        if(isUnpaged){
+            return ClubMemberSearchResponse.builder()
+                    .content(new ArrayList<>(clubSummaryMap.values()))
+                    .paginationInfo(new PaginationInfo(
+                            0,
+                            0,
+                            0,
+                            totalClubs
+                    ))
+                    .build();
+        }
+        else{
+            int totalPages = (int) Math.ceil((double) totalClubs / pageable.getPageSize());
 
-        int totalClubs = userClubIds.size();
-        int totalPages = (int) Math.ceil((double) totalClubs / pageable.getPageSize());
+            return ClubMemberSearchResponse.builder()
+                    .content(new ArrayList<>(clubSummaryMap.values()))
+                    .paginationInfo(new PaginationInfo(
+                            pageable.getPageNumber(),
+                            pageable.getPageSize(),
+                            totalPages,
+                            totalClubs
+                    ))
+                    .build();
+        }
+    }
+    @Override
+    public ClubSearchResponse getAllClubs(
+            String username,
+            Long currentPeopleMin,
+            Long currentPeopleMax,
+            Long totalPeopleMin,
+            Long totalPeopleMax,
+            String clubName,
+            ClubStatus status) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
 
-        return ClubMemberSearchResponse.builder()
-                .content(new ArrayList<>(clubSummaryMap.values()))
-                .paginationInfo(new PaginationInfo(
-                        pageable.getPageNumber(),
-                        pageable.getPageSize(),
-                        totalPages,
-                        totalClubs
-                ))
+        QClubMember cm = QClubMember.clubMember;
+        QClub club = QClub.club;
+
+        List<Long> userClubIds = queryFactory
+                .select(cm.club.id)
+                .from(cm)
+                .where(cm.user.id.eq(user.getId()))
+                .fetch();
+
+        Map<Long, Long> currentPeopleMap = queryFactory
+                .select(cm.club.id, cm.count())
+                .from(cm)
+                .where(cm.status.eq(MemberStatus.ACTIVE))
+                .groupBy(cm.club.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Long.class),
+                        tuple -> tuple.get(1, Long.class)
+                ));
+
+        Map<Long, Long> totalPeopleMap = queryFactory
+                .select(cm.club.id, cm.count())
+                .from(cm)
+                .groupBy(cm.club.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Long.class),
+                        tuple -> tuple.get(1, Long.class)
+                ));
+
+        List<Long> filteredClubIds = userClubIds.stream()
+                .filter(id -> {
+                    long current = currentPeopleMap.getOrDefault(id, 0L);
+                    long total = totalPeopleMap.getOrDefault(id, 0L);
+                    return (currentPeopleMin == null || current >= currentPeopleMin) &&
+                            (currentPeopleMax == null || current <= currentPeopleMax) &&
+                            (totalPeopleMin == null || total >= totalPeopleMin) &&
+                            (totalPeopleMax == null || total <= totalPeopleMax);
+                })
+                .collect(Collectors.toList());
+
+        if (filteredClubIds.isEmpty()) {
+            return ClubSearchResponse.builder()
+                    .content(new ArrayList<>())
+                    .build();
+        }
+
+        BooleanBuilder clubFilter = new BooleanBuilder();
+        clubFilter.and(club.id.in(filteredClubIds));
+        if(clubName != null && !clubName.isBlank()) {
+            clubFilter.and(club.name.eq(clubName));
+        }
+        if(status != null) {
+            clubFilter.and(club.status.eq(status));
+        }
+        List<Long> pagedClubIds = queryFactory
+                .select(club.id)
+                .from(club)
+                .where(clubFilter)
+                .orderBy(club.id.asc())
+                .fetch();
+
+
+        if(pagedClubIds.isEmpty()) {
+            return ClubSearchResponse.builder()
+                .content(new ArrayList<>())
+                .build();
+
+        }
+
+        QClubMember qMember = QClubMember.clubMember;
+        QUser qUser = QUser.user;
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        club.id,
+                        club.name,
+                        club.affiliation,
+                        club.status,
+                        qMember.id,
+                        qUser.username,
+                        qUser.major,
+                        qUser.studentNumber,
+                        qMember.role,
+                        qMember.status,
+                        qMember.registeredAt
+                )
+                .from(club)
+                .join(qMember).on(qMember.club.id.eq(club.id))
+                .join(qUser).on(qMember.user.id.eq(qUser.id))
+                .where(club.id.in(pagedClubIds))
+                .orderBy(club.id.asc())
+                .fetch();
+
+        Map<Long, ClubProjection.ClubDetail> clubDetailMap = new LinkedHashMap<>();
+
+        for (Tuple tuple : tuples) {
+            Long clubId = tuple.get(club.id);
+            clubDetailMap.computeIfAbsent(clubId, id -> new ClubProjection.ClubDetail(
+                    tuple.get(club.id),
+                    tuple.get(club.name),
+                    tuple.get(club.affiliation),
+                    tuple.get(club.status)
+            ));
+        }
+        return ClubSearchResponse.builder()
+                .content(new ArrayList<>(clubDetailMap.values()))
                 .build();
     }
     public User getUser(String username) {

--- a/src/main/java/com/example/dgu_semi_erp_back/usecase/user/UserUseCase.java
+++ b/src/main/java/com/example/dgu_semi_erp_back/usecase/user/UserUseCase.java
@@ -7,6 +7,8 @@ import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserResponse;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserRoleUpdateRequest;
 import com.example.dgu_semi_erp_back.dto.user.UserCommandDto.UserEmailUpdateRequest;
 import com.example.dgu_semi_erp_back.entity.auth.user.User;
+import com.example.dgu_semi_erp_back.entity.club.ClubStatus;
+import com.example.dgu_semi_erp_back.entity.club.MemberStatus;
 import com.example.dgu_semi_erp_back.projection.club.ClubProjection.ClubSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,5 +19,21 @@ public interface UserUseCase {
     User updateRole(Long id,UserRoleUpdateRequest request,String username);
     User updateEmail(Long userId, UserEmailUpdateRequest request,String username);
     User findUserByAccessToken(String accessToken);
-    UserClubMemberDto.ClubMemberSearchResponse getUserClubs(String accessToken, Pageable pageable);
+    UserClubMemberDto.ClubMemberSearchResponse getUserClubs(
+            String accessToken,
+            Long currentPeopleMin,
+            Long currentPeopleMax,
+            Long totalPeopleMin,
+            Long totalPeopleMax,
+            String clubName,
+            ClubStatus status,
+            Pageable pageable);
+    UserClubMemberDto.ClubSearchResponse getAllClubs(
+            String username,
+            Long currentPeopleMin,
+            Long currentPeopleMax,
+            Long totalPeopleMin,
+            Long totalPeopleMax,
+            String clubName,
+            ClubStatus status);
 }


### PR DESCRIPTION
## 🔎 관련 이슈
closed #64

## 🔎 작업 내용
- 동아리 목록 조회 API 조건 필터링 기능 개선

## 🔎 참고사항
# [동아리 목록 조회](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt#eea30b71-687a-48c5-af27-49fff13a415d)
![carbon](https://github.com/user-attachments/assets/6629a3ac-a301-4d2b-8564-88840e595b0a)

# [유저 소속 동아리 전체 조회](https://documenter.getpostman.com/view/33657317/2sB2cUAiAt#b5959155-b475-420a-83c2-fe1b8b5ccb35)
![carbon (2)](https://github.com/user-attachments/assets/d161ab53-b8df-46ad-96c1-75dead404a2f)
